### PR TITLE
docs: migrate Phase 1/2/3 sections into docs/nodes + docs/decisions (closes #5)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,12 +10,14 @@
 | 你想知道... | 去哪里 |
 |------------|--------|
 | 系统整体怎么跑的 | 继续读本文档 |
-| 某个节点的具体实现 | `docs/nodes/{编号}-{名称}.md` |
-| 某个设计为什么这样做 | `docs/decisions/{编号}-{主题}.md` |
+| 某个节点的具体实现 | `docs/nodes/{01-12}-*.md`（12 个节点详情） |
+| 某个设计为什么这样做 | `docs/decisions/{001-009}-*.md`（9 条 ADR） |
+| Phase 1/2/3（v0.5+）做了什么 | 本文档 Section 10 + 对应 ADR |
 | 数据结构定义 | 代码是真相源: `backend/models/agent_state.py`, `events.py`, `financial.py` |
 | API 端点格式 | 本文档 Section 7: API Contract |
 | 版本变更历史 | `CHANGELOG.md` |
 | MVP 上线差距 | `MVP-GAP.md` |
+| 新人上手 / 本地起服务 | `DEVELOPMENT.md` + `make help` |
 | AI Agent 开发指南 | `frontend/CLAUDE.md` |
 
 ---
@@ -125,7 +127,7 @@ alphaquant/
 ├── MVP-GAP.md                                   # MVP 差距分析与路线图
 │
 ├── docs/
-│   ├── nodes/                                   # 节点详细文档 (8 个)
+│   ├── nodes/                                   # 节点详细文档 (12 个)
 │   │   ├── 01-fetch-sec-data.md                 #   Node 1: SEC EDGAR 数据获取
 │   │   ├── 02-financial-health.md               #   Node 2: 财务健康扫描
 │   │   ├── 03-dcf-model.md                      #   Node 3: DCF 估值建模
@@ -133,15 +135,25 @@ alphaquant/
 │   │   ├── 05-event-sentiment.md                #   Node 5: 消息面情绪分析
 │   │   ├── 06-event-impact.md                   #   Node 6: 事件影响 + DCF 重算
 │   │   ├── 07-strategy.md                       #   Node 7: 买入策略
-│   │   └── 08-logic-trace.md                    #   Node 8: SEC 数据溯源
-│   └── decisions/                               # 架构决策记录 ADR (5 个)
+│   │   ├── 08-logic-trace.md                    #   Node 8: SEC 数据溯源
+│   │   ├── 09-qualitative-analysis.md           # 🆕 Node 9: 10-K MD&A + Risk Factors (Pro)
+│   │   ├── 10-risk-yoy-diff.md                  # 🆕 Node 10: 10-K Risk YoY 对比 (Pro)
+│   │   ├── 11-moat-analysis.md                  # 🆕 Node 11: 7 Powers 护城河评分 (Pro)
+│   │   └── 12-investment-thesis.md              # 🆕 Node 12: 综合投资论点 (Pro)
+│   └── decisions/                               # 架构决策记录 ADR (9 个)
 │       ├── 001-xbrl-tag-fallback.md             #   XBRL 标签回退策略
 │       ├── 002-two-stage-dcf.md                 #   两阶段 DCF 设计
 │       ├── 003-stream-writer-over-astream.md    #   StreamWriter 选择
 │       ├── 004-separate-recalc-endpoint.md      #   独立重算端点
-│       └── 005-fmp-stable-api.md                #   FMP /stable/ API 选择
+│       ├── 005-fmp-stable-api.md                #   FMP /stable/ API 选择
+│       ├── 006-unified-llm-client.md            # 🆕 LLM 单一调用入口
+│       ├── 007-three-layer-cost-guardrails.md   # 🆕 三层成本围栏
+│       ├── 008-pluggable-auth-providers.md      # 🆕 可插拔认证模块
+│       └── 009-tier-gating-strategy.md          # 🆕 节点级 tier 门控
 │
-├── backend/
+├── backend/                                     # 下方仅展示 v0.4 之前的核心结构;
+│   │                                            # v0.5/0.6/0.7 新增的 services/llm/, services/auth/,
+│   │                                            # prompts/, alembic/, 4 个 Pro nodes 等见 §10 完整目录树
 │   ├── pyproject.toml                           # Python 依赖定义
 │   ├── backend/
 │   │   ├── main.py                              # FastAPI 入口 + lifespan 管理
@@ -780,485 +792,153 @@ npm run dev
 输入 Ticker (如 NVDA), 观察左侧 Agent 推理链实时展示, 右侧组件逐个挂载。
 分析完成后拖动滑块调整假设参数, 点击重算即时看到估值变化 (策略仪表盘同步更新)。
 
-> **以下章节覆盖 v0.5 — v0.7 的新增内容（Phase 1 / 2 / 3）。** v0.4 之前的内容保持上方不变。
 
 ---
 
-## 11. Phase 1 — LLM 基础设施 + 成本围栏（v0.5.0）
+## 10. Beyond v0.4 — Phase 1 / 2 / 3 总览
 
-把 v0.3 / v0.4 中分散的 LLM 调用收编到统一框架，并叠加三层成本围栏防止生产事故。
+> v0.5 — v0.7 引入了 LLM 基础设施、5 个 Pro 分析节点、认证 + 订阅分级。**详细实现细节** 见 `docs/nodes/` 和 `docs/decisions/`；本节只提供高层导览。
 
-### 11.1 统一 LLM 调用栈
+### Phase 1 — LLM 基础设施 + 成本围栏（v0.5.0）
 
-```
-backend/backend/services/llm/
-├── client.py        # LLMClient.complete_json(prompt_name, variables, response_model, task_tag)
-├── providers.py     # OpenAICompatibleProvider（DeepSeek / OpenAI / 任何兼容协议）
-├── sanitize.py      # 输入净化 + 注入检测 + <<<USER_CONTENT>>> 边界包裹
-├── accounting.py    # AccountingStore：每次调用结构化日志 + 24h 滑动窗成本聚合
-├── budget.py        # BudgetGate：双闸熔断（global + per-IP）
-└── errors.py        # LLMError 基类 + LLMConfigError / LLMProviderError / LLMParseError / LLMBudgetExceeded
-```
+把分散的 LLM 调用收编到 `services/llm/` 统一入口，叠加三层成本围栏。
 
-调用流：
+| 主题 | 详细文档 |
+|------|---------|
+| LLM 单一调用入口（client / providers / sanitize / accounting / errors） | [ADR 006: unified-llm-client](decisions/006-unified-llm-client.md) |
+| 三层成本围栏（IP 限流 + per-IP 预算 + 全局预算） + admin 热改阈值 | [ADR 007: three-layer-cost-guardrails](decisions/007-three-layer-cost-guardrails.md) |
+| Prompt YAML 库（`backend/prompts/<name>_v<N>.yaml`） | 在 ADR 006 中 |
 
-```
-节点代码
-   │ LLMClient.complete_json(prompt_name="thesis", variables={...}, response_model=InvestmentThesis, task_tag="thesis")
-   ▼
-1. load_prompt(name, version)              ← 读 YAML，缓存
-2. template.user.format(**variables)
-3. sanitize_text / sanitize_list           ← HTML escape + 边界包裹
-4. BudgetGate.check(client_ip)             ← 双闸熔断（详见 11.3）
-5. provider.chat_completion(...)           ← OpenAI 协议 HTTPS 调用
-6. retry once on 429 / 5xx / parse error
-7. response_model.model_validate(parsed)   ← Pydantic 校验
-8. AccountingStore.record(client_ip,...)   ← 落 JSON 日志一行
-   ▼
-返回 BaseModel 实例（或 raise LLMError → 节点降级）
-```
+### Phase 3 — 5 个 LLM Pro 节点（v0.6.0）
 
-**关键不变性**：全站唯一入口；所有 LLM 调用都过这条流水线，没有节点能"偷偷直连 httpx"。
+分析管线从 8 节点扩到 12 节点。Pro 节点统一遵循「LLM 输出 → Pydantic 校验 → 逐字引文核验」防幻觉链路。
 
-### 11.2 Prompt 库
+| 节点 | 输入 | 详细文档 |
+|------|------|---------|
+| `qualitative_analysis` 🔒 | 10-K MD&A + Risk Factors（并行） | [Node 09](nodes/09-qualitative-analysis.md) |
+| `risk_yoy_diff` 🔒 | 当年 + 上一年 10-K Risk Factors | [Node 10](nodes/10-risk-yoy-diff.md) |
+| `moat_analysis` 🔒 | 10-K Item 1 Business | [Node 11](nodes/11-moat-analysis.md) |
+| `investment_thesis` 🔒 | 全部上游 state | [Node 12](nodes/12-investment-thesis.md) |
 
-`backend/backend/prompts/<name>_v<N>.yaml`，每个文件含：
+> 🔒 = Pro-only（详见 [ADR 009: tier-gating-strategy](decisions/009-tier-gating-strategy.md)）。
 
-```yaml
-name: investment_thesis
-version: 1
-model_hint: deepseek-chat
-temperature: 0.3
-max_tokens: 2500
-response_schema: InvestmentThesis
-system: |
-  ...
-user: |
-  Company: {ticker} ({company_name})
-  ...
-```
+### Phase 2 — 认证 + 订阅分级（v0.7.0）
 
-`load_prompt(name, version)` 启动期解析 + 缓存，运行期 0 额外 IO。
+引入用户身份系统（3 种登录方式 → 同一份 User row）+ Pro 节点 tier 门控。
 
-### 11.3 三层成本围栏
+| 主题 | 详细文档 |
+|------|---------|
+| 三 provider 模块化抽象（email/password + Magic link + Google OAuth） | [ADR 008: pluggable-auth-providers](decisions/008-pluggable-auth-providers.md) |
+| Pro 节点 tier 门控（节点入口 short-circuit + 锁定预览卡） | [ADR 009: tier-gating-strategy](decisions/009-tier-gating-strategy.md) |
+
+### 完整管线（12 节点）
 
 ```
-请求进入
-  │
-  ▼  IP 限流（services/rate_limit.py）
-  │   每 IP 24h 滑动窗 N 次（默认 /analyze=3, /recalculate-dcf=30）
-  │   超限 → HTTP 429 + Retry-After，零 SEC/LLM 调用
-  ▼
-  路由处理 → bind_client_ip(ip) 进 contextvar
-  │
-  ▼  LangGraph 跑各节点；遇到 LLM 调用时 …
-  │
-  ▼  Per-IP LLM 预算（services/llm/budget.py）
-  │   单 IP 24h 累计 spend ≥ AQ_LLM_PER_IP_DAILY_BUDGET_USD
-  │   → LLMBudgetExceeded(scope=per_ip) → 节点降级
-  ▼
-  ▼  全局 LLM 预算
-  │   全部 IP 24h 累计 spend ≥ AQ_LLM_DAILY_BUDGET_USD
-  │   → LLMBudgetExceeded(scope=global) → 当天剩余所有 LLM 调用全降级
-  ▼
-  实际 HTTPS 到 LLM provider
+fetch_sec_data → financial_health_scan → dynamic_dcf → relative_valuation
+              → event_sentiment [LLM]  → event_impact [2× LLM]
+              → strategy
+              → qualitative_analysis [2× LLM, Pro]   ← MD&A + Risk Factors 并行
+              → risk_yoy_diff        [LLM, Pro]      ← 双源核验
+              → moat_analysis        [LLM, Pro]      ← 7 Powers
+              → investment_thesis    [LLM, Pro]      ← 综合研报
+              → logic_trace
 ```
 
-阈值由 `services/runtime_settings.RuntimeSettings` 管理：env 提供启动默认，admin API 提供运行时覆盖（重启回 env）。
+Free 用户跑 7 个 free 节点 + 4 个 Pro 节点 emit 锁定预览卡（0 LLM 调用）；Pro 用户跑全部 12 节点。
 
-### 11.4 Admin API（`backend/backend/api/admin.py`）
-
-```
-Bearer AQ_ADMIN_TOKEN 保护（token 空时整路由 503）
-├── GET  /api/admin/settings                看 effective + overrides
-├── PATCH /api/admin/settings               动态改预算/限流（SettingsPatch extra=forbid）
-├── POST /api/admin/settings/reset          一键回 env
-├── GET  /api/admin/usage                   24h 花费、按 task 分组、按 IP top10、限流命中
-└── PATCH /api/admin/users/{email}/tier     手动升降级（v0.7 加入）
-```
-
-### 11.5 Token 计费日志格式
-
-每次成功 LLM 调用发一条 JSON line（`logger=llm.accounting`）：
-
-```json
-{
-  "task_tag": "thesis",
-  "provider": "primary",
-  "model": "deepseek-chat",
-  "input_tokens": 2143,
-  "output_tokens": 487,
-  "estimated_cost_usd": 0.000437,
-  "duration_ms": 2174,
-  "timestamp": 1714008342.7,
-  "client_ip": "203.0.113.42"
-}
-```
-
-可直接喂给 `jq` / log pipeline 做聚合。
-
----
-
-## 12. Phase 3 — 5 个 LLM Pro 节点（v0.6.0）
-
-分析管线从 8 节点扩到 12 节点。新增的 5 个节点都是研究密集型 LLM 任务，遵循统一防幻觉链路。
-
-### 12.1 完整管线（12 节点）
-
-```
-fetch_sec_data
-    ↓
-financial_health_scan
-    ↓
-dynamic_dcf
-    ↓
-relative_valuation
-    ↓
-event_sentiment            [LLM #1]
-    ↓
-event_impact               [LLM #2 + #3]   两步：filter → analysis
-    ↓
-strategy
-    ↓
-qualitative_analysis       [LLM #4 + #5, Pro]   并行：MD&A + Risk Factors
-    ↓
-risk_yoy_diff              [LLM #6, Pro]   今年 vs 去年 10-K
-    ↓
-moat_analysis              [LLM #7, Pro]   Helmer 7 Powers
-    ↓
-investment_thesis          [LLM #8, Pro]   综合研报
-    ↓
-logic_trace
-```
-
-单次完整分析 8 次 LLM 调用，DeepSeek 全程 ~$0.01。
-
-### 12.2 5 个新 Pro 节点
-
-| 节点 | 输入 | 输出 schema | 引文核验 |
-|------|------|-------------|---------|
-| `qualitative_analysis` (MD&A 部分) | 10-K Item 7（前 12K 字符，head+tail） | `MDNAInsight`：tone / forward_guidance / drivers / concerns / notable_quotes | `verify_quotes()` 丢弃幻觉引文 |
-| `qualitative_analysis` (Risk Factors 部分) | 10-K Item 1A（前 16K 字符，head only） | `RiskFactorInsight`：8 类风险计数 / Top 5 risks / concentration_risk | `_verify_risk_quote()` 丢弃整条 risk |
-| `risk_yoy_diff` | 当年 + 去年 10-K Item 1A（各 12K） | `RiskYoYDiff`：4 桶（new / removed / escalated / de-escalated） | 双源核验：new 验 current；removed 验 prior；escalated/de-escalated 双向都验 |
-| `moat_analysis` | 10-K Item 1（前 12K，head+tail） | `MoatInsight`：7 powers 各 0-10 + classification + primary_powers | 不可核验时把 score demote 到 0（保留行结构） |
-| `investment_thesis` | 全部上游 state | `InvestmentThesis`：headline + recommendation + bull/bear/risks + action_summary | — |
-
-### 12.3 防幻觉机制（共三层）
-
-1. **System prompt 强约束**：每个 prompt 明令"只能从 USER_CONTENT 边界内提取，禁止使用训练数据知识"。Prompt 文件在 `backend/backend/prompts/`。
-2. **Pydantic 模型校验**：`response_model` 强制类型/枚举/长度，校验失败 → `LLMParseError` → 节点降级。
-3. **逐字引文核验**（最关键）：所有从源文本抽取的引文都过 `verify_quotes()` —— 必须是源文本的 substring（白空格归一化 + smart-quote 归一化）。
-   - MD&A: 假引文丢弃
-   - Risk Factors: 整条 risk 丢弃
-   - YoY diff: 双源都得过，否则整条 change 丢弃
-   - Moat: score 降到 0，rationale 加 `[demoted]` 前缀
-
-### 12.4 10-K 解析（`services/tenk_parser.py`）
-
-提取三节内容，每节用三层正则回退（strict_multi_ws → loose_any_ws → fallback）+ "取最后一次出现"自动避开 ToC：
-
-| 函数 | 节 | 边界 |
-|------|---|------|
-| `extract_mdna(html)` | Item 7 Management's Discussion and Analysis | → Item 7A 或 Item 8 |
-| `extract_risk_factors(html)` | Item 1A Risk Factors | → Item 1B 或 Item 2 |
-| `extract_business(html)` | Item 1 Business | → Item 1A |
-
-截断助手：
-
-- `smart_truncate(text, max_chars)`: 头 + 尾 + 中间 `[...truncated...]` 标记。MD&A / Business 用（保留 Overview + Liquidity）。
-- `truncate_head(text, max_chars)`: 仅头部。Risk Factors 用（公司按重要性排序，头部即关键）。
-
-### 12.5 SEC 客户端 10-K 多年获取
-
-`SECClient.fetch_10k(cik, n_back=N)`：n_back=0 是最新，n_back=1 是上一年，以此类推。**进程级 6 条 FIFO HTML 缓存**（按 accession_number），同一请求多个节点共享下载。
-
-### 12.6 前端组件
-
-`frontend/src/components/analysis/`：
-
-| 组件 | 内容 |
-|------|------|
-| `investment-thesis-card.tsx` | Bull/Bear/Risks 三栏 + recommendation 徽章 + confidence |
-| `qualitative-insights-card.tsx` | tone 徽章 + forward guidance + 双栏（drivers/concerns）+ verbatim quotes |
-| `risk-factors-card.tsx` | 8 类风险徽章条 + Top risks 列表（category 图标 + severity 徽章 + 引文） |
-| `risk-yoy-diff-card.tsx` | 4 桶 2x2 网格；escalated/de_escalated 显示 prior↔current 并排引文 |
-| `moat-analysis-card.tsx` | 7 power 渐变进度条 + primary badge + verbatim 引文 |
-| `pro-locked-card.tsx` | **共享**锁定预览卡片（4 个 Pro `*_locked_card` 都映射到这个，详见 §13.4） |
-
----
-
-## 13. Phase 2 — 认证 + 订阅分级（v0.7.0）
-
-引入用户身份系统：3 种登录方式 + Postgres 持久化 + JWT 会话 + Pro 节点 tier 门控。
-
-### 13.1 数据 schema
-
-```
-users
-├── id (PK)
-├── email (UNIQUE, INDEX)
-├── password_hash (NULL for OAuth-only / magic-link-only users)
-├── tier             ← CHECK ('free'|'pro'|'admin')
-├── is_active
-├── email_verified
-├── display_name
-└── created_at / updated_at / last_login_at
-
-identity_providers
-├── id (PK)
-├── user_id (FK→users, ON DELETE CASCADE)
-├── kind             ← CHECK ('email_password'|'magic_link'|'google')
-├── external_id      ← email for password/magic_link, Google sub for google
-├── created_at / last_used_at
-├── UNIQUE (user_id, kind)        ← 同一用户同一 kind 至多一行
-└── UNIQUE (kind, external_id)    ← 同一 Google sub 不能挂两个用户
-```
-
-支持「同一邮箱挂多种登录方式」：用户先用密码注册，再点"用 Google 登录"会把 Google identity 行链接到同一 `users.id`。
-
-### 13.2 三种登录方式 + 同一份 AuthService
-
-```
-邮箱密码 ─┐
-Magic Link ─┼─→ AuthService.upsert_*_user(...) → User row + IdentityProvider row → JWT cookie
-Google OAuth ─┘
-```
-
-每种 provider 是 `services/auth/` 下的一个独立模块，外部只通过 `AuthService` 访问，便于后续扩展（GitHub OAuth / Apple Sign-in / SAML 等只需加一个文件 + 一组路由）。
-
-### 13.3 认证流程
-
-#### Email + Password
-```
-POST /api/auth/email/register {email, password, display_name?}
-   → User 创建 (tier=AQ_DEFAULT_USER_TIER, password_hash=bcrypt(...))
-   → IdentityProvider(kind='email_password', external_id=email)
-   → JWT 写入 aq_session cookie + 返回 body
-
-POST /api/auth/email/login {email, password}
-   → bcrypt verify (恒定时间, 防 timing oracle)
-   → 同上
-```
-
-#### Magic Link（无密码）
-```
-POST /api/auth/magic-link/send {email}
-   → itsdangerous URLSafeTimedSerializer.dumps({email})
-   → 发邮件（Resend HTTP API；无 key 时 stderr 打印 + 响应中返 dev_link）
-   → 返回 {sent: true}（不暴露用户是否存在，防枚举）
-
-GET (浏览器点邮件链接) /auth/magic-link/verify?token=...
-   → 前端调 POST /api/auth/magic-link/verify {token}
-   → itsdangerous loads(token, max_age=15min)
-   → AuthService.upsert_magic_link_user(email)
-       - 不存在 → 创建（email_verified=True，因为邮件可达即证明持有）
-       - 存在但未验证 → 翻 email_verified=True
-   → 链接 IdentityProvider(kind='magic_link') + JWT cookie
-```
-
-#### Google OAuth（authlib OIDC）
-```
-GET /api/auth/google/start
-   → SessionMiddleware 生成 state
-   → 302 重定向到 Google authorize endpoint
-
-GET /api/auth/google/callback?code=...&state=...
-   → authlib exchange code → access_token + id_token
-   → 解出 userinfo（sub, email, name, email_verified）
-   → AuthService.upsert_google_user(google_sub, email, ...)
-       - 优先按 google_sub 找已链接用户
-       - 否则按 email 找现有用户并链接 Google identity
-       - 都没有 → 新建 user
-   → JWT cookie + 302 → 前端首页
-```
-
-### 13.4 Tier 门控
-
-```
-api/routes.py /analyze
-   ↓ Depends(get_optional_user)              ← 匿名也通过，user=None
-   ↓ user_tier = user.tier if user else "free"
-   ↓ initial_state["user_tier"] = user_tier
-   ↓ LangGraph 跑节点
-       │
-       ├─ 4 个 Pro 节点（thesis/qualitative/risk_yoy_diff/moat）开头：
-       │     if not is_pro_user(state):                     ← _pro_gate.is_pro_user(state)
-       │         return emit_lock(...).payload              ← 推一条 *_locked_card ComponentEvent
-       │
-       └─ 7 个 Free 节点：照常跑
-```
-
-`_pro_gate.emit_lock(...)` 推送的 `ComponentEvent` 带 `feature_label` / `entity_name` / `preview_*`，前端 `pro-locked-card.tsx` 渲染锁定预览 + Upgrade CTA。
-
-4 个 Pro 节点对应的 locked component_type：
-- `investment_thesis_locked_card`
-- `qualitative_locked_card`
-- `risk_yoy_diff_locked_card`
-- `moat_locked_card`
-
-四者全部映射到同一个 React 组件 `pro-locked-card.tsx`，由后端注入的 `feature_label` 驱动文案差异。
-
-### 13.5 会话凭证
-
-JWT (HS256) 同时通过两条路下发：
-
-| 渠道 | 适用 |
-|------|------|
-| `aq_session` HTTP-only cookie（`SameSite=Lax`） | 浏览器 SPA |
-| 响应 body `{token}` | API 客户端（可放 `Authorization: Bearer`） |
-
-`get_optional_user` / `get_current_user` 两个 FastAPI dep 都先看 cookie 再看 header。
-
-### 13.6 前端
-
-```
-src/context/auth-context.tsx       ← <AuthProvider> + useAuth()
-                                     status ∈ {loading, authenticated, anonymous}
-                                     isPro 派生属性
-src/lib/auth-api.ts                ← 类型化 fetch wrappers
-src/app/auth/login/page.tsx        ← 三 tab：Password / Magic link / Google
-src/app/auth/register/page.tsx     ← 邮箱密码注册
-src/app/auth/magic-link/verify/page.tsx ← 接 ?token= → 调 verify → 跳首页
-```
-
-`<AuthProvider>` 在 root layout 包裹 `<HistoryProvider>` 外层，全站可用 `useAuth()`。
-
-### 13.7 手工 Pro 升级（pre-Stripe）
-
-```bash
-# 升级
-curl -X PATCH \
-  -H "Authorization: Bearer $AQ_ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"tier":"pro"}' \
-  http://localhost:8000/api/admin/users/foo@bar.com/tier
-
-# 或：
-make promote EMAIL=foo@bar.com
-```
-
-Stripe 集成留待后续；当前 admin 接口长期保留作为运营覆盖手段。
-
----
-
-## 14. 完整目录结构（截至 v0.7.0）
+### 完整目录结构（v0.7 后）
 
 ```
 alpha/
-├── docker-compose.yml              # Postgres for local dev
+├── docker-compose.yml              # Local Postgres
 ├── Makefile                         # 一键 dev/test/migrate/promote
 ├── scripts/dev-setup.sh             # 一次性 bootstrap
 ├── DEVELOPMENT.md                   # 共同开发者上手指南
-├── ARCHITECTURE.md                  # ← 本文件
+├── ARCHITECTURE.md                  # ← 本文件（系统全景）
 ├── CHANGELOG.md
-├── MVP-GAP.html
+├── MVP-GAP.md / MVP-GAP.html
+│
+├── docs/
+│   ├── nodes/                       # 节点详细文档（12 个）
+│   │   ├── 01-fetch-sec-data.md
+│   │   ├── 02-financial-health.md
+│   │   ├── 03-dcf-model.md
+│   │   ├── 04-relative-valuation.md
+│   │   ├── 05-event-sentiment.md
+│   │   ├── 06-event-impact.md
+│   │   ├── 07-strategy.md
+│   │   ├── 08-logic-trace.md
+│   │   ├── 09-qualitative-analysis.md   # 🆕 v0.6
+│   │   ├── 10-risk-yoy-diff.md          # 🆕 v0.6
+│   │   ├── 11-moat-analysis.md          # 🆕 v0.6
+│   │   └── 12-investment-thesis.md      # 🆕 v0.6
+│   └── decisions/                   # ADR（架构决策记录）
+│       ├── 001-xbrl-tag-fallback.md
+│       ├── 002-two-stage-dcf.md
+│       ├── 003-stream-writer-over-astream.md
+│       ├── 004-separate-recalc-endpoint.md
+│       ├── 005-fmp-stable-api.md
+│       ├── 006-unified-llm-client.md           # 🆕 v0.5
+│       ├── 007-three-layer-cost-guardrails.md  # 🆕 v0.5
+│       ├── 008-pluggable-auth-providers.md     # 🆕 v0.7
+│       └── 009-tier-gating-strategy.md         # 🆕 v0.7
 │
 ├── backend/
-│   ├── alembic.ini
-│   ├── alembic/
-│   │   ├── env.py                   # Async migration runner
-│   │   └── versions/
-│   │       └── 20260425_0001_init_users.py
-│   ├── pyproject.toml
-│   ├── .env / .env.example
-│   ├── backend/
-│   │   ├── main.py                  # + SessionMiddleware, auth_router, DB lifespan
-│   │   ├── config.py                # 全部 AQ_* env 字段
-│   │   ├── api/
-│   │   │   ├── routes.py            # /analyze + /recalculate-dcf (含 IP 限流 + tier 注入)
-│   │   │   ├── admin.py             # /api/admin/* (settings + usage + users/{email}/tier)
-│   │   │   ├── auth.py              # /api/auth/* (8 路由 covering 3 providers)
-│   │   │   └── dependencies.py
-│   │   ├── agents/
-│   │   │   ├── value_analyst.py     # 12 节点 StateGraph
-│   │   │   └── nodes/
-│   │   │       ├── _pro_gate.py     # 共享 tier 门控 helper
-│   │   │       ├── financial_health.py
-│   │   │       ├── dcf_model.py
-│   │   │       ├── relative_valuation.py + relative_valuation_math.py
-│   │   │       ├── event_sentiment.py + event_sentiment_math.py
-│   │   │       ├── event_impact.py + event_impact_math.py
-│   │   │       ├── strategy.py
-│   │   │       ├── qualitative_analysis.py    # MD&A + Risk Factors 并行
-│   │   │       ├── risk_yoy_diff.py           # 双源核验
-│   │   │       ├── moat_analysis.py           # Helmer 7 Powers
-│   │   │       ├── investment_thesis.py       # 综合研报
-│   │   │       └── logic_trace.py
-│   │   ├── prompts/
-│   │   │   ├── __init__.py          # YAML loader + cache
-│   │   │   ├── sentiment_v1.yaml
-│   │   │   ├── event_filter_v1.yaml
-│   │   │   ├── event_analysis_v1.yaml
-│   │   │   ├── mdna_analysis_v1.yaml
-│   │   │   ├── risk_factors_v1.yaml
-│   │   │   ├── risk_yoy_diff_v1.yaml
-│   │   │   ├── moat_analysis_v1.yaml
-│   │   │   └── investment_thesis_v1.yaml
-│   │   ├── services/
-│   │   │   ├── ticker_resolver.py
-│   │   │   ├── sec_client.py        # + fetch_10k(n_back) + 6条FIFO HTML缓存
-│   │   │   ├── sec_agent.py
-│   │   │   ├── tenk_parser.py       # extract_mdna / extract_risk_factors / extract_business
-│   │   │   ├── market_data.py
-│   │   │   ├── finnhub_client.py
-│   │   │   ├── llm_sentiment.py     # 改瘦身 wrapper，走 LLMClient
-│   │   │   ├── db.py                # Async SQLAlchemy engine
-│   │   │   ├── runtime_settings.py  # env defaults + admin overrides
-│   │   │   ├── request_context.py   # contextvars for client IP
-│   │   │   ├── rate_limit.py        # IP rate limiter
-│   │   │   ├── llm/
-│   │   │   │   ├── client.py        # LLMClient
-│   │   │   │   ├── providers.py     # OpenAICompatibleProvider
-│   │   │   │   ├── sanitize.py
-│   │   │   │   ├── accounting.py    # AccountingStore
-│   │   │   │   ├── budget.py        # BudgetGate
-│   │   │   │   └── errors.py
-│   │   │   └── auth/
-│   │   │       ├── models.py         # User + IdentityProvider ORM
-│   │   │       ├── service.py        # AuthService
-│   │   │       ├── passwords.py      # bcrypt
-│   │   │       ├── tokens.py         # JWT
-│   │   │       ├── magic_link.py     # itsdangerous + Resend
-│   │   │       ├── google_oauth.py   # authlib OIDC
-│   │   │       └── dependencies.py   # get_current_user / require_pro / ...
-│   │   └── models/
-│   │       ├── agent_state.py       # + user_tier + qualitative_result + risk_yoy_diff_result + moat_result + investment_thesis_result
-│   │       ├── events.py
-│   │       ├── financial.py
-│   │       └── sec.py
-│   └── tests/
+│   ├── alembic.ini + alembic/                  # DB migrations (v0.7)
+│   ├── pyproject.toml + .env.example
+│   └── backend/
+│       ├── main.py + config.py
+│       ├── api/{routes, admin, auth, dependencies}.py    # admin/auth 是 v0.5/v0.7 新增
+│       ├── agents/
+│       │   ├── value_analyst.py                          # 12 节点 graph
+│       │   └── nodes/
+│       │       ├── (8 个原节点)
+│       │       ├── _pro_gate.py                          # 🆕 v0.7 tier 门控 helper
+│       │       ├── qualitative_analysis.py               # 🆕 v0.6
+│       │       ├── risk_yoy_diff.py                      # 🆕 v0.6
+│       │       ├── moat_analysis.py                      # 🆕 v0.6
+│       │       └── investment_thesis.py                  # 🆕 v0.6
+│       ├── prompts/                                       # 🆕 v0.5 YAML library
+│       │   └── {sentiment, event_filter, event_analysis,
+│       │       mdna_analysis, risk_factors, risk_yoy_diff,
+│       │       moat_analysis, investment_thesis}_v1.yaml
+│       ├── services/
+│       │   ├── (原有 sec / market_data / finnhub / ticker_resolver)
+│       │   ├── tenk_parser.py                            # 🆕 v0.6 10-K HTML 解析
+│       │   ├── db.py + runtime_settings.py + request_context.py + rate_limit.py
+│       │   ├── llm/                                       # 🆕 v0.5 unified LLM
+│       │   │   └── {client, providers, sanitize, accounting, budget, errors}.py
+│       │   └── auth/                                      # 🆕 v0.7 auth 模块
+│       │       └── {models, service, passwords, tokens, magic_link, google_oauth, dependencies}.py
+│       └── models/
+│           └── agent_state.py                            # + user_tier + 4 个 Pro result fields
 │
 └── frontend/
     └── src/
         ├── app/
-        │   ├── layout.tsx           # 包了 AuthProvider
-        │   ├── page.tsx
         │   ├── analyze/[ticker]/page.tsx
-        │   └── auth/                # ← 新增（v0.7）
-        │       ├── login/page.tsx           # 三 tab
+        │   └── auth/                                     # 🆕 v0.7
+        │       ├── login/page.tsx                        #   3 tab: password / magic / google
         │       ├── register/page.tsx
         │       └── magic-link/verify/page.tsx
         ├── context/
         │   ├── history-context.tsx
-        │   └── auth-context.tsx     # ← 新增
-        ├── hooks/
-        │   ├── use-sse.ts
-        │   └── use-analysis-stream.ts
+        │   └── auth-context.tsx                          # 🆕 v0.7
+        ├── hooks/{use-sse, use-analysis-stream}.ts
         ├── lib/
-        │   ├── types.ts             # + Tier / AuthUser / AuthSessionResponse
-        │   ├── constants.ts
-        │   ├── auth-api.ts          # ← 新增
-        │   └── utils.ts
+        │   ├── auth-api.ts                               # 🆕 v0.7
+        │   ├── types.ts (+ Tier / AuthUser)
+        │   └── ...
         └── components/
-            ├── component-registry.ts  # 18 entries (12 free + 4 Pro + 4 locked aliases）
+            ├── component-registry.ts                     # 18 entries
             └── analysis/
                 ├── (12 个 free 卡片)
-                ├── investment-thesis-card.tsx     # 4 Pro 卡片
+                ├── investment-thesis-card.tsx            # 4 Pro 卡片 (v0.6)
                 ├── qualitative-insights-card.tsx
                 ├── risk-factors-card.tsx
                 ├── risk-yoy-diff-card.tsx
                 ├── moat-analysis-card.tsx
-                └── pro-locked-card.tsx            # 共享锁定预览
+                └── pro-locked-card.tsx                   # 共享锁定预览 (v0.7)
 ```
 
-> **注**: 未设置 `AQ_FMP_API_KEY` 时, 相对估值和策略分析自动跳过。未设置 `AQ_FINNHUB_API_KEY` 时, 消息面情绪节点自动跳过。其余功能正常。在 `.env` 中设置即可启用, config.py 会自动从项目根目录向上查找该文件。
+> **注**: 未设置 `AQ_FMP_API_KEY` 时, 相对估值和策略分析自动跳过。未设置 `AQ_FINNHUB_API_KEY` 时, 消息面情绪节点自动跳过。未设置 `AQ_LLM_API_KEY` 时, 所有 LLM 节点（含 5 个 Pro 节点）跳过。未设置 `AQ_DATABASE_URL` 时, auth 整套禁用，所有用户被视为 anonymous（free tier）。在 `.env` 中按需启用即可。

--- a/docs/decisions/006-unified-llm-client.md
+++ b/docs/decisions/006-unified-llm-client.md
@@ -1,0 +1,91 @@
+# ADR 006: Unified LLM Client as Single Chokepoint
+
+**状态**: 已采纳
+**日期**: 2026-04-24 (v0.5.0, Phase 1)
+**影响节点**: event_sentiment, event_impact, qualitative_analysis, risk_yoy_diff, moat_analysis, investment_thesis
+**相关代码**: `backend/services/llm/`, `backend/prompts/`
+
+## 背景
+
+v0.4 之前，每个用 LLM 的节点（`llm_sentiment.py`、`event_impact.py`）自己 `import httpx` 直连 DeepSeek，prompt 写在 Python 字符串常量里，没有统一的 token 计费、错误处理、重试、Provider 抽象。继续这样写下去：
+
+- 加一个 LLM 节点 = 复制 80 行模板代码
+- 想换 provider（DeepSeek → OpenAI）= 改 N 个文件
+- 想要 budget gate / 限流 = 没法塞进散落的调用点
+- prompt 散在代码里，不能 diff 看版本变化
+
+## 考虑的方案
+
+### 方案 A: 继续现状（每个节点自己 httpx）
+- 短期最快
+- 问题：上面 4 个痛点全部不解决
+- 问题：到 Phase 3 多加 5 个 LLM 节点时会爆炸
+
+### 方案 B: 用 LangChain 的 LLM 抽象 (`ChatOpenAI` / `ChatAnthropic` 等)
+- 自带 Provider 切换
+- 问题：LangChain 的依赖很重，项目刻意保持轻（纯 httpx + pydantic）
+- 问题：LangChain 的 prompt 模板系统 (`PromptTemplate`) 和 Pydantic 校验集成不顺
+- 问题：cost / token 追踪不是开箱即用，仍要手写
+
+### 方案 C: 自建 LLMClient 单一入口 ✓
+- 100% 走 httpx，零新依赖
+- 编排所有横切关注点：prompt 加载、输入净化、预算检查、重试、计费、Pydantic 校验
+- 通过 `task_tag` 字符串区分调用类型 → admin 可以基于 task_tag 做路由 / 预算分桶
+
+## 决策
+
+采用方案 C。`backend/services/llm/` 提供唯一调用入口：
+
+```python
+LLMClient.complete_json(
+    prompt_name="moat_analysis",        # 从 backend/prompts/{name}_v{version}.yaml 加载
+    version=1,
+    variables={"ticker": ..., ...},
+    response_model=MoatInsight,         # Pydantic 强制结构
+    task_tag="moat",                    # budget / 路由 / 计费 / 日志的归类键
+)
+```
+
+**搜不到任何节点直接 `httpx.post` 到 LLM provider 的代码**——这是项目的不变性约束。
+
+### 模块拆分
+
+| 文件 | 职责 |
+|------|------|
+| `client.py` | `LLMClient` 主类 + 全局 singleton + `complete_json` 编排所有步骤 |
+| `providers.py` | `OpenAICompatibleProvider`（DeepSeek / OpenAI / 任何 OpenAI 协议兼容） |
+| `sanitize.py` | HTML 转义 + 控制字符剔除 + `<<<USER_CONTENT>>>` 边界包裹 + 注入模式检测 |
+| `accounting.py` | `AccountingStore`：每次调用结构化日志一行 + 24h 滑动窗成本聚合（per-IP & 全局） |
+| `budget.py` | `BudgetGate`：双闸熔断（详见 [ADR 007](007-three-layer-cost-guardrails.md)） |
+| `errors.py` | `LLMError` 基类 + `LLMConfigError` / `LLMProviderError` / `LLMParseError` / `LLMBudgetExceeded` |
+
+### Prompt 库
+
+`backend/prompts/<name>_v<N>.yaml`，每个文件含 `system` / `user` 两段 + tuning 默认（`temperature` / `max_tokens`） + `response_schema` 名称。`load_prompt(name, version)` 启动期解析 + 缓存，运行期 0 额外 IO。
+
+### Provider 路由
+
+`task_tag in {"thesis", "report_summary"}` 路由到 narrative provider（`AQ_LLM_NARRATIVE_*`）；其它走 primary。narrative 没配则 fallback 到 primary。
+
+### IP propagation
+
+每次请求 `bind_client_ip(ip)` 进 `contextvars.ContextVar`；`LLMClient.complete_json` 内部 `current_client_ip()` 读取，写入 `accounting.record(client_ip=...)` —— 不用层层传参。
+
+## 后果
+
+**正面**:
+- 加一个 LLM 节点 = 加一个 prompt YAML + 一个 Pydantic 模型 + 一个节点（节点本身只 ~100 行）
+- 切换 provider 改一个 env var；切换 task → narrative provider 路由改一个常量
+- Budget gate / 计费 / 日志全部一次实现，所有调用点免费享受
+- Prompt 可以 git diff，可以版本化（`v1` / `v2` 共存）
+- 测试容易：mock `LLMClient.complete_json`，节点其它逻辑保持纯函数
+
+**负面**:
+- 多了一层抽象，新人需要先理解 `LLMClient` 才能加节点（缓解：本 ADR + node 模板）
+- Pydantic 校验失败的错误信息有时不够友好（缓解：`LLMParseError` 包了 ValidationError 的 message）
+- httpx 客户端是全局 singleton，并发限制由其内部连接池控制（够用但不够灵活）
+
+**未来扩展点**:
+- [ ] 多 Provider 路由表（admin 在 RuntimeSettings 里热改）—— L2 settings 工作
+- [ ] 用户级 BYOK（per-user API key）—— L4 settings 工作
+- [ ] Streaming 支持 (`complete_text` 当前不实现 streaming) —— Q&A chat 功能时需要

--- a/docs/decisions/007-three-layer-cost-guardrails.md
+++ b/docs/decisions/007-three-layer-cost-guardrails.md
@@ -1,0 +1,117 @@
+# ADR 007: Three-Layer Cost Guardrails
+
+**状态**: 已采纳
+**日期**: 2026-04-24 (v0.5.0, Phase 1)
+**影响节点**: 所有 LLM 节点 + `/api/analyze` / `/api/recalculate-dcf` 路由
+**相关代码**: `backend/services/rate_limit.py`, `backend/services/llm/budget.py`, `backend/services/runtime_settings.py`, `backend/api/admin.py`
+
+## 背景
+
+公开链接前必须解决的两类风险：
+
+1. **DDoS / 滥用**：单个 IP 一分钟刷 100 次 `/analyze`，每次触发 8-12 个外部 API 调用（SEC + FMP + Finnhub + LLM × N），账户被刷爆。
+2. **LLM 成本失控**：DeepSeek 单次 ~$0.01，但出错的 prompt 或者 oversized input 可能跑出 $1+ 单次调用；每天累计可能超出预算。
+
+需要在**调用真正发生之前**就拦下来，并且支持运维**不重启就能调阈值**。
+
+## 考虑的方案
+
+### 方案 A: 仅靠 LLM provider 的 rate limit
+- 不做事，依赖 DeepSeek 自己限流
+- 问题：provider 限流通常是按账户的，不区分用户/IP；一个滥用者可以让所有用户的请求都 429
+- 问题：账单已经产生才发现来不及
+
+### 方案 B: 应用层单层限流（IP rate limit only）
+- 用 `slowapi` 之类做 IP 限流
+- 问题：限流不等于成本控制，限流额度内仍可能跑出高成本调用
+- 问题：单层不够，被绕过没有第二道防线
+
+### 方案 C: 三层防御（IP 限流 + per-IP 预算 + 全局预算） ✓
+- 三层独立触发，互为冗余
+- IP 限流挡 DDoS（拒绝路由进入，零调用成本）
+- per-IP 预算挡"在限流额度内但调用很贵"
+- 全局预算挡"分布式滥用从不同 IP 来的"
+- 三层阈值均运行时可调（RuntimeSettings）
+
+## 决策
+
+采用方案 C。
+
+### 三层闸门（从外到内）
+
+```
+请求来                         IP=1.2.3.4
+  │
+  ▼  ① IP 限流 (services/rate_limit.py)
+  │   IPRateLimiter.check_and_record(bucket="analyze", client_ip)
+  │   24h 滑动窗 dict[(bucket, ip)] -> deque[timestamps]
+  │   超限 → HTTP 429 + Retry-After (零调用成本)
+  ▼
+  bind_client_ip(ip) 进 contextvars
+  ▼
+  Pro 节点跑到 LLMClient.complete_json
+  ▼  ② Per-IP LLM 预算 (services/llm/budget.py)
+  │   accounting.spend_since(24h, client_ip="1.2.3.4") ≥ AQ_LLM_PER_IP_DAILY_BUDGET_USD?
+  │   超限 → LLMBudgetExceeded(scope=per_ip) → 节点 except LLMError → 降级
+  ▼
+  ▼  ③ 全局预算
+  │   accounting.spend_since(24h, all) ≥ AQ_LLM_DAILY_BUDGET_USD?
+  │   超限 → LLMBudgetExceeded(scope=global) → 当天剩余所有 LLM 调用降级
+  ▼
+  实际 HTTPS → DeepSeek
+  ▼
+  accounting.record(client_ip, input/output_tokens, cost) → 进 24h 滑动窗
+```
+
+### Runtime 配置（两层）
+
+env 提供启动默认，admin API 提供运行时覆盖。读取统一走 `RuntimeSettings.snapshot()` —— admin 改完下次调用立即生效。
+
+```python
+# services/runtime_settings.py 暴露的字段
+llm_daily_budget_usd: float           # 全局, 默认 5.0
+llm_per_ip_daily_budget_usd: float    # 单 IP, 默认 0.25
+rate_limit_analyze_per_ip_day: int    # /analyze, 默认 3
+rate_limit_recalculate_per_ip_day: int # /recalculate-dcf, 默认 30
+```
+
+### Admin API（`/api/admin/`，Bearer token）
+
+```bash
+GET  /api/admin/usage              # 24h 花费 + 按 task / IP 分组
+PATCH /api/admin/settings          # 改任一阈值，立即生效
+POST /api/admin/settings/reset     # 一键回 env 默认
+```
+
+### 存储
+
+- 限流：内存 `defaultdict[(bucket, ip), deque[timestamps]]`，FIFO 清理 24h 之外
+- 预算：内存 ring buffer (max 2000 条 `LLMUsageRecord`) + 每条 JSON 日志一行（log pipeline 可聚合）
+
+## 后果
+
+**正面**:
+- 公开链接放心发——最坏情况花费被双层预算扣死
+- 任意 IP 一天花费上限 $0.25 = 即使限流被绕过单 IP 损失可控
+- 所有阈值热改：发推前临时压低 budget；发推后看到反响调高
+- 三层独立 → 任一层有 bug 不会让另两层也失效
+- 单 admin API 同时管"安全"和"成本"，运维心智一致
+
+**负面**:
+- 单实例内存存储，多实例部署需要换 Redis（current scope 是 single instance MVP）
+- 进程重启 → 内存数据清空 → 当天累计花费"重置" → 短窗口内的预算保护被绕过（缓解：日志可重建；正式环境会接 Postgres）
+- IP 限流对走代理 / NAT 的真实用户不友好（缓解：未来加入登录用户后用 user_id 替代 IP 作为 key）
+- 每个 LLM 调用前多两次 dict 查询 + 一次 sum（开销 microseconds 级，可忽略）
+
+**降级行为**:
+
+| 触发 | 用户体验 |
+|------|---------|
+| HTTP 429 | 前端应该显示 "今日免费额度用完, 24h 后重置 / 升级 Pro"（待做：见 [DEVELOPMENT.md 已知 tech debt](../../DEVELOPMENT.md)） |
+| LLMBudgetExceeded | 用户看不到差别（和 LLM provider 自身错误走同一降级路径，节点 skip） |
+| 节点 skip | 上层分析继续；只是缺这部分 LLM 输出 |
+
+**未决问题**:
+- [ ] 是否要给 Pro 用户更高的限流额度（e.g. 50/day）—— 等 Phase 2 接 auth 后再做（已完成 Phase 2，可以做这个 follow-up）
+- [ ] 全局预算耗尽时是否给登录用户透支额度 —— BYOK（[ADR 006](006-unified-llm-client.md) 未来扩展点）解决方案
+- [ ] Redis 集群版限流（multi-instance 部署前必需）

--- a/docs/decisions/008-pluggable-auth-providers.md
+++ b/docs/decisions/008-pluggable-auth-providers.md
@@ -1,0 +1,127 @@
+# ADR 008: Pluggable Auth Providers
+
+**状态**: 已采纳
+**日期**: 2026-04-25 (v0.7.0, Phase 2)
+**影响节点**: `/api/auth/*` 路由, `/api/analyze` 的 `Depends(get_optional_user)`
+**相关代码**: `backend/services/auth/`, `backend/api/auth.py`, `backend/alembic/versions/20260425_0001_init_users.py`
+
+## 背景
+
+Phase 2 要引入用户身份系统。要回答：
+
+1. 支持哪几种登录方式？（密码 / Magic link / Google OAuth / Apple / GitHub / SAML / ...）
+2. 选什么不影响"以后想换 / 加"的灵活性？
+3. 数据库 schema 怎么设计才能支持"同一邮箱可挂多种登录方式"？
+
+合作开发者明确要求：**Auth 这个部分能够单独作为一个模块 push**。意味着模块化抽象是硬要求。
+
+## 考虑的方案
+
+### 方案 A: 仅邮箱 + 密码
+- 最少代码
+- 问题：用户体验差（必须记密码）；MVP 转化率受影响
+- 问题：不支持 enterprise SSO（未来路径堵死）
+
+### 方案 B: 用第三方 auth-as-a-service（Auth0 / Clerk / Supabase Auth）
+- 完全托管，开箱即用
+- 问题：每月固定成本（Auth0 ~$23/mo for 1000 users）
+- 问题：用户数据在第三方，未来迁移成本高
+- 问题：合规要求（GDPR / SOC 2）依赖第三方
+
+### 方案 C: 自建 + 三种 provider，模块化抽象 ✓
+- 三种登录方式（邮箱密码 / Magic link / Google OAuth）覆盖 95% 用户偏好
+- 每种 provider 是独立 Python 模块，符合"模块单独 push"要求
+- 数据自主，未来可加 GitHub / Apple / SAML 不需要重构
+- 零月租，仅在使用 Resend / Google OAuth 时付服务费
+
+## 决策
+
+采用方案 C。
+
+### 模块边界（`backend/services/auth/`）
+
+```
+__init__.py         公共出口：User / AuthService / Tier / get_current_user / require_pro
+models.py           SQLAlchemy ORM：User + IdentityProvider
+service.py          AuthService：唯一的"业务逻辑入口"，外部不直接调 provider
+passwords.py        bcrypt 哈希 + 校验（cost=12）
+tokens.py           JWT (HS256) 签发 + 解码
+dependencies.py     FastAPI deps: get_current_user / get_optional_user / require_pro / require_admin_tier
+providers/
+    email_password  通过 service 直接处理（无独立 module，逻辑简单）
+    magic_link.py   itsdangerous URLSafeTimedSerializer + Resend HTTP API + stderr fallback
+    google_oauth.py authlib OIDC client（lazy init, is_configured() check）
+```
+
+### Schema 设计：两表，one-to-many
+
+```
+users (
+  id, email UNIQUE, password_hash NULL, tier CHECK (free|pro|admin),
+  is_active, email_verified, display_name, ...
+)
+identity_providers (
+  id, user_id FK→users CASCADE, kind CHECK (email_password|magic_link|google),
+  external_id, ...,
+  UNIQUE (user_id, kind),       ← 同一用户同一 kind 至多一行
+  UNIQUE (kind, external_id)    ← 同一 Google sub 不能挂两个用户
+)
+```
+
+**为什么不用 polymorphic columns**: 把 `google_sub` / `magic_token` 全塞 users 表会让 schema 跟着 provider 数量膨胀，每加一个 provider = 一次 migration。`identity_providers` 表用 `kind` + `external_id` 通用化，加 GitHub / Apple 只需在 CHECK 约束里加一行。
+
+### 上层 funnel：`AuthService`
+
+三种 provider 的 verify 完成后都进同一个 `AuthService.upsert_*_user`：
+
+```
+邮箱密码  ──┐
+Magic Link ─┼─→ AuthService.upsert_*_user(...)  
+Google     ─┘     ├── 1. 优先用 provider-specific external_id 找
+                  ├── 2. 其次按 email 找现有用户并链接 identity 行
+                  ├── 3. 都没找到 → 新建 user + identity
+                  └── 返回 User → routes 签 JWT cookie
+```
+
+**关键性质**：同一邮箱用三种方式登录，最终都映射到同一个 `users.id`。后续行为按 `user_id` 操作，与登录方式解耦。
+
+### 加新 provider 的步骤（e.g. GitHub）
+
+1. 加一个 `services/auth/github_oauth.py`（mirror `google_oauth.py`）
+2. `AuthService` 加 `upsert_github_user(github_id, email, ...)`（可复用 `upsert_google_user` 模式）
+3. 配置加 `AQ_GITHUB_OAUTH_*` env vars
+4. routes 加 `/api/auth/github/start` + `/callback`
+5. 前端 login 页加一个 "Sign in with GitHub" tab
+6. **Migration**: 加一行 `ALTER TABLE identity_providers DROP CONSTRAINT ck_identity_kind; ALTER TABLE ... ADD CONSTRAINT ck_identity_kind CHECK (kind IN ('email_password', 'magic_link', 'google', 'github'));`
+
+无需改 `AuthService` 的核心逻辑、JWT、tier、依赖、前端 AuthContext。
+
+### 会话凭证：JWT 双下发
+
+| 渠道 | 适用 |
+|------|------|
+| `aq_session` HTTP-only cookie (SameSite=Lax) | 浏览器 SPA |
+| 响应 body `{token}` | API 客户端（放 `Authorization: Bearer`） |
+
+`get_optional_user` 同时读 cookie 和 header，优先 cookie。tier 字段从 DB 实时读（不依赖 JWT 内 tier），admin 升降级**立即生效**。
+
+## 后果
+
+**正面**:
+- 加 provider = 加一个文件 + migration 一行；零核心改动
+- 用户多种登录方式可以混用（邮箱密码注册 → 后续用 Google 直接登录同一账号）
+- AuthService 是单一测试边界，每个 provider 模块独立 mock
+- 数据自主：用户表是我们自己的，未来 BYOK / SSO / 数据导出全可控
+- JWT + cookie 让前端 AuthContext 实现简单（自动跟随 fetch）
+
+**负面**:
+- 比第三方方案多 ~600 行代码 + Alembic + bcrypt 等依赖（缓解：长期价值高）
+- 多 provider 测试矩阵复杂（缓解：smoke test 用 mock；E2E 用 staging Google OAuth）
+- 没有 MFA / passkey 支持（缓解：MVP 不要求；未来加在 service 层）
+- Magic link 在 Resend 没配时只能 stderr 兜底（缓解：dev 友好；prod 必须配 Resend）
+
+**未决问题**:
+- [ ] 邮箱验证流程（密码注册的用户 `email_verified=False` 但没有"发验证邮件"端点）—— Magic link 路径已经能做兜底验证
+- [ ] "忘记密码"流程 —— 故意不做，让 magic link 兼任
+- [ ] 用户偏好（如 BYOK / 默认 LLM）—— 加 `users.preferences` JSONB 列即可，未触动 auth 模块边界
+- [ ] Stripe 订阅集成 —— 加 `webhooks.py` 监听 Stripe events 调 `AuthService.set_tier`，模块边界稳定

--- a/docs/decisions/009-tier-gating-strategy.md
+++ b/docs/decisions/009-tier-gating-strategy.md
@@ -1,0 +1,122 @@
+# ADR 009: Tier Gating at Node Entry, Not at Route Layer
+
+**状态**: 已采纳
+**日期**: 2026-04-25 (v0.7.0, Phase 2)
+**影响节点**: investment_thesis, qualitative_analysis, risk_yoy_diff, moat_analysis
+**相关代码**: `backend/agents/nodes/_pro_gate.py`, `backend/api/routes.py`, `frontend/src/components/analysis/pro-locked-card.tsx`
+
+## 背景
+
+4 个 LLM Pro 节点要按 `user.tier ∈ {free, pro, admin}` 分级访问。两条主流路径，权衡点完全相反：
+
+- 路由层门控：`/api/analyze` 直接 `Depends(require_pro)` 拒绝 free
+- 节点层门控：路由全员通过，每个 Pro 节点开头 short-circuit
+
+这是一个产品决策，不只是工程决策。
+
+## 考虑的方案
+
+### 方案 A: 路由层门控 — `/api/analyze` 加 `Depends(require_pro)`
+- 实现一行代码
+- 问题：**free 用户看不到任何东西**（包括 7 个数值节点）→ 失去免费工具的拉新价值
+- 问题：用户体验"全或无"，转化率结构差（用户没尝过 Pro 价值就被挡）
+- 问题：违反产品定位（"白盒可信的 DCF 分析" 是公开宣传，不该挡用户）
+
+### 方案 B: 路由层细分两个 endpoint — `/analyze`（free）+ `/analyze/pro`（pro）
+- 数据流分叉，前端要决策走哪个
+- 问题：业务逻辑重复，graph 要 build 两套
+- 问题：节点配置漂移风险
+
+### 方案 C: 节点层门控 + 锁定预览卡 ✓
+- 路由全员通过，所有 12 节点都跑（free 跑 7 个，4 个 Pro 节点 emit 预览卡 + 0 LLM 调用）
+- free 用户能看到完整框架（DCF / 估值 / 财务健康 / 信号），有真实价值
+- Pro 节点的"被锁"很可见（带 Upgrade CTA + 部分免费 preview 数据）→ 成为天然转化漏斗
+- 路由层零变更，每个 Pro 节点 5 行 short-circuit 代码
+
+### 方案 D: 在 LLM Client 里门控
+- 任何 Pro task_tag 调用前检查 user_tier
+- 问题：LLM Client 是基础设施，不该有业务概念（哪些 task 是 Pro 是策略，会变）
+- 问题：拒绝时机晚 — 节点已经做了 SEC fetch / parse，浪费 IO
+
+## 决策
+
+采用方案 C。
+
+### 实现：`_pro_gate.py` 共享 helper
+
+```python
+# 4 个 Pro 节点开头都这样写
+if not is_pro_user(state):
+    return emit_lock(
+        writer=writer,
+        node_name="moat_analysis",
+        feature_label="Moat / 7 Powers scoring",
+        locked_component_type="moat_locked_card",
+        state_field="moat_result",
+        ticker=financials.ticker,
+        entity_name=financials.entity_name,
+    ).payload   # → {"moat_result": None, "reasoning_steps": ["...gated..."]}
+```
+
+`emit_lock(...)` 推 3 条 SSE：
+1. `agent_thinking`（"This is a Pro feature. Skipping for free tier."）
+2. `component`（`*_locked_card` 携带 feature_label 和可选预览数据）
+3. `step_complete`
+
+### 用户身份注入路径
+
+```
+api/routes.py /analyze:
+  ↓ Depends(get_optional_user)        ← 匿名通过, user=None
+  ↓ user_tier = user.tier if user else "free"
+  ↓ initial_state["user_tier"] = user_tier
+  ↓ LangGraph 跑 12 节点
+      └── 4 Pro 节点开头 is_pro_user(state) 短路
+```
+
+**关键性质**：tier 从 DB 实时读取（[ADR 008](008-pluggable-auth-providers.md)），admin 升降级 → 用户下次请求**立即**生效，无需重新登录。
+
+### 锁定预览的 4 个 component_type
+
+每个 Pro 节点 emit 自己的 `*_locked_card`，前端 registry 全部映射到同一个 React 组件 `pro-locked-card.tsx`：
+
+```ts
+// frontend/src/components/component-registry.ts
+investment_thesis_locked_card: lazy(() => import("./analysis/pro-locked-card")),
+qualitative_locked_card:        lazy(() => import("./analysis/pro-locked-card")),
+risk_yoy_diff_locked_card:      lazy(() => import("./analysis/pro-locked-card")),
+moat_locked_card:               lazy(() => import("./analysis/pro-locked-card")),
+```
+
+后端注入 `feature_label` 给组件，文案差异化由 props 驱动而非组件树。
+
+### 免费预览的"钩子"信息
+
+`investment_thesis_locked_card` 携带 `strategy_result.signal` 和 `margin_of_safety_pct` —— 免费用户能看到"Overvalued / -61%"这样的硬数字结论，但看不到完整论点。这是**最强的转化钩子**：用户看到"被高估 61%"会想知道为什么 → 升级。
+
+## 后果
+
+**正面**:
+- Free 用户得到真实有价值的产品（7 节点全部能用），没被坑
+- Pro 价值在用户面前可见但锁住 → 自然漏斗
+- 路由层零业务感知，添加 Pro 节点不改路由
+- LLM 0 调用成本（节点 short-circuit 在所有外部 IO 之前）
+- 测试简单：mock state["user_tier"] 即可单测每个分支
+
+**负面**:
+- 节点必须显式调 `is_pro_user(state)` —— 漏掉就成了"Pro 功能免费送"（缓解：所有 Pro 节点的开头是模板代码 + code review checklist）
+- 4 个 Pro 节点开头都有同样 5 行（缓解：抽 `_pro_gate.emit_lock(...)` helper, 无重复逻辑）
+- 前端要为每个 Pro 节点准备 locked card 文案 / 预览（缓解：单一组件 + 后端注入 feature_label, 文案在一处）
+
+**降级行为**:
+
+| 场景 | Free 用户看到 | Pro 用户看到 |
+|------|--------------|-------------|
+| 主流 happy path | 7 节点输出 + 4 个 locked card | 12 节点全部输出 |
+| LLM 未配置 | 7 节点 + 4 个 locked card（locked 优先于 LLM check） | 7 节点 + 4 个 "LLM not configured" skip event |
+| 某个 Pro 节点 LLM 失败 | 不受影响（永远是 locked） | 7 节点 + 3 Pro 卡片 + 1 个 "LLM error" skip event |
+
+**未决问题**:
+- [ ] 限流是否按 tier 区分（free 3/day, Pro 50/day）—— 当前都按 IP 默认 3/day，Pro 用户应该有更高额度（follow-up）
+- [ ] tier=admin 的具体含义未定义 —— 当前等同于 pro，未来可能加"绕过 budget gate"等特权
+- [ ] 锁定预览的"钩子"数据要不要随 Pro 节点的能力升级而变更（e.g. moat_locked_card 也带 overall_moat_score 数字预览？）

--- a/docs/nodes/09-qualitative-analysis.md
+++ b/docs/nodes/09-qualitative-analysis.md
@@ -1,0 +1,246 @@
+# Node 9: qualitative_analysis 🔒 Pro
+
+> 图位置: `strategy → qualitative_analysis → risk_yoy_diff`
+
+## 职责
+
+拉取最新 10-K 一次，**并行**抽取 Item 7 (MD&A) 和 Item 1A (Risk Factors) 两节文本，分别用 LLM 提炼定性洞察：管理层语气、前瞻指引、增长驱动 / 担忧、风险分类与 Top 5 风险。每条引文必须是源文本的逐字 substring，幻觉引文自动丢弃。
+
+## 输入
+
+> **真相源**: `backend/models/agent_state.py` — `AnalysisState`
+
+### State 字段
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|:----:|------|
+| `financials` | `CompanyFinancials` | ✅ | → [Node 1 输出](01-fetch-sec-data.md#companyfinancials-结构体) |
+| `user_tier` | `str` | ✅ | `"free"` 短路 emit locked card；`"pro"` / `"admin"` 才执行 |
+
+### 子字段访问
+
+| 访问路径 | 类型 | 必需 | 用途 |
+|----------|------|:----:|------|
+| `financials.cik` | `int` | ✅ | 拉取该公司 10-K 的 SEC EDGAR 索引 |
+| `financials.ticker` | `str` | ✅ | LLM prompt + 日志 |
+| `financials.entity_name` | `str` | ✅ | LLM prompt + ComponentEvent props |
+
+### AAPL 示例 (输入子字段)
+
+```json
+{
+  "user_tier": "pro",
+  "financials": {
+    "ticker": "AAPL",
+    "entity_name": "Apple Inc.",
+    "cik": 320193
+  }
+}
+```
+
+---
+
+## 输出
+
+### State 更新
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `qualitative_result` | `dict \| None` | 嵌套结构 `{mdna, risk_factors}` (见下) |
+| `reasoning_steps` | `list[str]` | 追加到推理链 |
+
+### `qualitative_result` 结构体
+
+> **源码**: `backend/agents/nodes/qualitative_analysis.py` line 415-442
+
+```python
+{
+    "ticker": str,
+    "filing_date": str,                    # ISO date, e.g. "2025-10-31"
+    "accession_number": str,               # e.g. "0000320193-25-000079"
+    "filing_url": str,                     # SEC Archives 直链 .htm
+    "mdna": dict | None,                   # ↓ 失败时 None
+    "risk_factors": dict | None,           # ↓ 失败时 None
+}
+```
+
+**`mdna` 子结构** (LLM 输出 → Pydantic `MDNAInsight`):
+
+```python
+{
+    "tone": "optimistic|neutral|cautious|negative",
+    "forward_guidance_summary": str,       # 1-3 句前瞻指引
+    "growth_drivers": list[str],           # 3-5 条
+    "management_concerns": list[str],      # 3-5 条
+    "notable_quotes": list[str],           # 已逐字核验, 最多 6 条
+    "rejected_quote_count": int,           # 被丢弃的幻觉引文数
+    "confidence": float,                   # [0, 1]
+    "parser_strategy": str,                # "strict_multi_ws" / "loose_any_ws" / "fallback_loose"
+    "parser_version": int,                 # 当前为 1
+    "mdna_char_count": int,                # 抽出原文长度
+    "llm_sent_char_count": int,            # 实际喂给 LLM 长度 (smart_truncate 后)
+}
+```
+
+**`risk_factors` 子结构** (Pydantic `RiskFactorInsight`):
+
+```python
+{
+    "risk_categories": dict[Category, int],  # e.g. {"regulatory": 5, "competitive": 3}
+    "top_risks": [
+        {
+            "category": "regulatory|competitive|operational|financial|macro|technology|legal|concentration",
+            "title": str,                  # 4-10 词总结
+            "description": str,            # 1-2 句解释
+            "severity": "high|medium|low",
+            "quote": str,                  # 已逐字核验, ≥40 字符
+        },
+        ...                                # 最多 5 条
+    ],
+    "rejected_risk_count": int,            # 被丢弃的不可核验 risk 数
+    "concentration_risk": str | None,      # 高度集中风险（客户 / 地区 / 产品）
+    "confidence": float,
+    "parser_strategy": str,
+    "parser_version": int,
+    "risk_char_count": int,
+    "llm_sent_char_count": int,
+}
+```
+
+### AAPL 示例 (实际抓出的真实数据 + LLM 模拟输出)
+
+```json
+{
+  "qualitative_result": {
+    "ticker": "AAPL",
+    "filing_date": "2025-10-31",
+    "accession_number": "0000320193-25-000079",
+    "filing_url": "https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/aapl-20250927.htm",
+    "mdna": {
+      "tone": "cautious",
+      "forward_guidance_summary": "Management expects continued macro headwinds offset by Services momentum and installed-base growth.",
+      "growth_drivers": ["Services revenue growth across App Store, cloud, and financial services", "Installed-base expansion driving recurring revenue"],
+      "management_concerns": ["Foreign-exchange headwinds on international revenue", "Regulatory scrutiny (DMA, antitrust investigations)"],
+      "notable_quotes": ["The following discussion should be read in conjunction with the consolidated financial statements and accompanying notes included in Part II, Item 8 of this Form 10-K."],
+      "rejected_quote_count": 1,
+      "confidence": 0.72,
+      "parser_strategy": "strict_multi_ws",
+      "mdna_char_count": 18020,
+      "llm_sent_char_count": 11969
+    },
+    "risk_factors": {
+      "risk_categories": {"regulatory": 5, "competitive": 3, "macro": 4, "concentration": 2},
+      "top_risks": [
+        {
+          "category": "regulatory",
+          "title": "DMA / antitrust exposure",
+          "description": "Digital Markets Act and ongoing investigations could require material business model changes.",
+          "severity": "high",
+          "quote": "The following summarizes factors that could have a material adverse effect on the Company's business, reputation, results of operations, financial condition and stock price."
+        }
+      ],
+      "rejected_risk_count": 1,
+      "concentration_risk": "Significant component sourcing dependency on limited number of suppliers.",
+      "confidence": 0.82,
+      "parser_strategy": "strict_multi_ws",
+      "risk_char_count": 68047,
+      "llm_sent_char_count": 16073
+    }
+  }
+}
+```
+
+## 核心算法
+
+```
+1. is_pro_user(state) check (_pro_gate.py)
+   └── False (free tier) → emit qualitative_locked_card → return None
+
+2. is_llm_configured() check
+   └── False → emit skipped event → return None
+
+3. sec_client.fetch_10k(cik, n_back=0)
+   └── 命中 6-entry FIFO HTML 缓存？复用，否则 GET /submissions/CIK*.json
+       + 下载 primary_document .htm (≤20MB, 否则拒绝)
+
+4. 并行解析 (in-process, no I/O):
+   ├── extract_mdna(html)       → ExtractedSection 或 None
+   └── extract_risk_factors(html) → ExtractedSection 或 None
+
+   两节都 None → emit skipped → return None
+   只有一节解析成功 → 仅跑那一节的 LLM
+
+5. asyncio.gather(_analyze_mdna(...), _analyze_risk_factors(...), return_exceptions=True)
+   ├── _analyze_mdna: smart_truncate(text, 12K) → LLMClient.complete_json("mdna_analysis")
+   │                  → verify_quotes(notable_quotes, source_text) → 丢弃幻觉
+   └── _analyze_risk_factors: truncate_head(text, 16K) → LLMClient.complete_json("risk_factors")
+                              → 每条 top_risk 的 quote 用 _verify_risk_quote 核验
+                              → 不通过的整条 risk 丢弃
+
+6. 部分成功 OK：成功的那部分 emit ComponentEvent，失败的略过
+   ├── mdna 成功 → emit qualitative_insights_card
+   └── risk_factors 成功 → emit risk_factors_card
+
+7. 组装嵌套 qualitative_result = {ticker, filing_date, ..., mdna: ..., risk_factors: ...}
+```
+
+## 关键假设
+
+- 10-K 一年只更新一次，HTML 内容稳定（缓存命中率高）
+- MD&A 结构是「Overview → Results → Liquidity → Critical Accounting」，head + tail 截断保留 LLM 最有用部分（XBRL 已捕获 Results 数值）
+- Risk Factors 公司按重要性排序，head-only 截断保留最关键风险
+- 幻觉引文是常态，**逐字核验是真正的防线**（system prompt 的指令是辅助）
+- 部分成功比整体失败有价值——MD&A 失败但 Risk Factors 成功仍然给用户出半张卡片
+
+## LLM 使用
+
+| 调用 | task_tag | Prompt | 输入 | 输出 |
+|------|----------|--------|------|------|
+| MD&A 分析 | `mdna` | `prompts/mdna_analysis_v1.yaml` | ticker + company_name + filing_date + accession + 12K MD&A 文本 | `MDNAInsight` |
+| Risk Factors 抽取 | `risk_factors` | `prompts/risk_factors_v1.yaml` | ticker + company_name + filing_date + accession + 16K Risk Factors 文本 | `RiskFactorInsight` |
+
+两次调用通过 `asyncio.gather` 并行，节省 ~2s 端到端延迟。
+
+## 失败模式与降级
+
+| 条件 | 行为 |
+|------|------|
+| `user_tier="free"` | emit `qualitative_locked_card` (Pro 锁定预览), 返回 None |
+| `financials.cik` 缺失 | emit skipped, 返回 None |
+| LLM 未配置 | emit skipped, 返回 None |
+| `fetch_10k` 失败 (网络 / 404 / 非 HTML primary doc) | emit skipped, 返回 None |
+| 两节都解析失败 | emit skipped, 返回 None |
+| 仅一节解析成功 | 仅跑那一节的 LLM, 另一节 None |
+| LLM 调用任一节失败 (402 / parse error / budget exceeded) | 该节 None, 另一节继续 |
+| 引文核验失败 | 整条引文 / 整条 risk 丢弃, 不影响其它字段 |
+| **下游影响** | `investment_thesis` 仍能跑；缺失字段在 thesis prompt 里显示 "not available" |
+
+## 源文件
+
+| 文件 | 职责 |
+|------|------|
+| `backend/agents/nodes/qualitative_analysis.py` | 节点入口 + 并行调度 + Pydantic 模型定义 + 引文核验 |
+| `backend/agents/nodes/_pro_gate.py` | tier 门控 helper |
+| `backend/services/tenk_parser.py` | `extract_mdna` / `extract_risk_factors` / `smart_truncate` / `truncate_head` |
+| `backend/services/sec_client.py` | `fetch_10k(cik, n_back)` + FIFO HTML 缓存 |
+| `backend/services/llm/client.py` | `LLMClient.complete_json` 单一入口 |
+| `backend/prompts/mdna_analysis_v1.yaml` | MD&A 抽取 prompt |
+| `backend/prompts/risk_factors_v1.yaml` | Risk Factors 抽取 prompt |
+
+## 与其他节点的关系
+
+- **依赖**: `fetch_sec_data` (cik); 不依赖 `strategy` 但顺序在它后面 (LangGraph 串行)
+- **消费者**: `risk_yoy_diff` 共用 10-K HTML 缓存; `investment_thesis` 通过 `_qualitative_summary()` 读取 `mdna` + `risk_factors` 字段写入 thesis prompt
+
+## 前端组件
+
+| component_type | 组件 | 触发条件 |
+|----------------|------|----------|
+| `qualitative_insights_card` | `QualitativeInsightsCard` — tone 徽章 + 前瞻指引 + 增长驱动/担忧双栏 + verbatim quotes | mdna 分析成功 |
+| `risk_factors_card` | `RiskFactorsCard` — 8 类徽章条 + Top risks 列表 + concentration callout | risk_factors 分析成功 |
+| `qualitative_locked_card` | `ProLockedCard` (shared) — Pro 升级 CTA | `user_tier="free"` |
+
+## 相关 ADR
+
+- [009 — tier-gating-strategy](../decisions/009-tier-gating-strategy.md)
+- [006 — unified-llm-client](../decisions/006-unified-llm-client.md)

--- a/docs/nodes/10-risk-yoy-diff.md
+++ b/docs/nodes/10-risk-yoy-diff.md
@@ -1,0 +1,219 @@
+# Node 10: risk_yoy_diff 🔒 Pro
+
+> 图位置: `qualitative_analysis → risk_yoy_diff → moat_analysis`
+
+## 职责
+
+抓**当年 + 上一年**两份 10-K 的 Item 1A Risk Factors，让 LLM 做 4 桶 YoY diff：新增风险 / 删除风险 / 加重风险 / 减轻风险。每条变化必须有**来自正确年份**的逐字引文支撑，否则丢弃。这是少数能反映管理层风险态度变化的客观信号。
+
+## 输入
+
+> **真相源**: `backend/models/agent_state.py` — `AnalysisState`
+
+### State 字段
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|:----:|------|
+| `financials` | `CompanyFinancials` | ✅ | → [Node 1 输出](01-fetch-sec-data.md#companyfinancials-结构体) |
+| `user_tier` | `str` | ✅ | `"free"` 短路 emit locked card |
+
+### 子字段访问
+
+| 访问路径 | 类型 | 必需 | 用途 |
+|----------|------|:----:|------|
+| `financials.cik` | `int` | ✅ | 拉两年 10-K 的索引 |
+| `financials.ticker` | `str` | ✅ | LLM prompt + 日志 |
+| `financials.entity_name` | `str` | ✅ | LLM prompt |
+
+不依赖 `qualitative_result` —— 重新独立解析两年 RF，避免错过去年数据。
+
+### AAPL 示例 (输入子字段)
+
+```json
+{
+  "user_tier": "pro",
+  "financials": {"ticker": "AAPL", "entity_name": "Apple Inc.", "cik": 320193}
+}
+```
+
+---
+
+## 输出
+
+### State 更新
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `risk_yoy_diff_result` | `dict \| None` | 4 桶 diff 结果 (结构见下) |
+| `reasoning_steps` | `list[str]` | 追加到推理链 |
+
+### `risk_yoy_diff_result` 结构体
+
+> **源码**: `backend/agents/nodes/risk_yoy_diff.py` line 252-279
+
+```python
+{
+    "ticker": str,
+    "current_filing": {
+        "filing_date": str,                    # ISO date
+        "accession_number": str,
+        "url": str,                            # SEC Archives 直链
+    },
+    "prior_filing": {
+        "filing_date": str,
+        "accession_number": str,
+        "url": str,
+    },
+    "summary": str,                            # 2-3 句年度风险态度总结
+    "new_risks":          list[RiskChange],    # ↓ 见下, 最多 4 条
+    "removed_risks":      list[RiskChange],
+    "escalated_risks":    list[RiskChange],
+    "de_escalated_risks": list[RiskChange],
+    "rejected_change_count": int,              # 引文核验未通过被丢弃总数
+    "confidence": float,                       # [0, 1]
+}
+```
+
+**`RiskChange` 子结构** (Pydantic):
+
+```python
+{
+    "kind": "new" | "removed" | "escalated" | "de_escalated",
+    "category": "regulatory|competitive|operational|financial|macro|technology|legal|concentration",
+    "title": str,                              # 5-12 词总结
+    "description": str,                        # 1-2 句解释
+    "quote_current": str | None,               # 当年 RF 中的逐字引文 (≥40 chars)
+    "quote_prior":   str | None,               # 上年 RF 中的逐字引文 (≥40 chars)
+}
+```
+
+**核验规则** (`_verify_change` in `risk_yoy_diff.py`):
+
+| kind | quote_current 要求 | quote_prior 要求 |
+|------|:--:|:--:|
+| `new` | ✅ 必须验证通过 | (忽略) |
+| `removed` | (忽略) | ✅ 必须验证通过 |
+| `escalated` | ✅ 必须验证通过 | ✅ 必须验证通过 |
+| `de_escalated` | ✅ 必须验证通过 | ✅ 必须验证通过 |
+
+任一必需引文未通过 → 整条 RiskChange 丢弃。
+
+### AAPL 示例 (实际抓出的真实 filings + LLM 模拟输出)
+
+```json
+{
+  "risk_yoy_diff_result": {
+    "ticker": "AAPL",
+    "current_filing": {
+      "filing_date": "2025-10-31",
+      "accession_number": "0000320193-25-000079",
+      "url": "https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/aapl-20250927.htm"
+    },
+    "prior_filing": {
+      "filing_date": "2024-11-01",
+      "accession_number": "0000320193-24-000123",
+      "url": "https://www.sec.gov/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm"
+    },
+    "summary": "Risk posture in 2025 emphasizes regulatory exposure under DMA-style regimes; previously generic risk framing has been replaced by specific antitrust language.",
+    "new_risks": [
+      {
+        "kind": "new",
+        "category": "regulatory",
+        "title": "DMA enforcement intensifies",
+        "description": "EU Digital Markets Act compliance became materially more concrete this year.",
+        "quote_current": "The following summarizes factors that could have a material adverse effect on the Company's business, reputation, results of operations, financial condition and stock price.",
+        "quote_prior": null
+      }
+    ],
+    "removed_risks": [],
+    "escalated_risks": [],
+    "de_escalated_risks": [],
+    "rejected_change_count": 2,
+    "confidence": 0.7
+  }
+}
+```
+
+## 核心算法
+
+```
+1. is_pro_user(state) → False → emit risk_yoy_diff_locked_card → return None
+2. is_llm_configured() → False → emit skipped → return None
+
+3. 并行 (or 顺序复用 cache):
+   ├── current = sec_client.fetch_10k(cik, n_back=0)  → extract_risk_factors
+   └── prior   = sec_client.fetch_10k(cik, n_back=1)  → extract_risk_factors
+
+   任一缺失或解析失败 → emit skipped → return None
+   (注: current 通常已被 qualitative_analysis 缓存命中, prior 是这里第一次拉)
+
+4. truncate_head(text, 12_000) 各自截到 12K (两段加起来 ~24K input tokens)
+
+5. LLMClient.complete_json("risk_yoy_diff", response_model=RiskYoYDiff)
+   └── 失败 (402 / parse / budget) → emit skipped → return None
+
+6. 4 桶分别过 _filter_changes(items, current_text, prior_text):
+   ├── 每条 RiskChange 用 _verify_change(...) 检查必需引文
+   └── 不通过的整条丢弃, 累加 rejected_change_count
+
+7. 组装结果, emit ComponentEvent("risk_yoy_diff_card")
+```
+
+## 关键假设
+
+- 公司每年的 Risk Factors 节是同一拨律师写的，**真实变化 = 法律视角认为值得专门改的**
+- "新增风险" 比 "加重风险" 信号更强（管理层不会无故加新风险段落）
+- 同一引文出现在两年都是常态（boilerplate），LLM 应该忽略这类
+- prior year 解析失败的概率比 current 高（旧格式可能不同），需要降级容忍
+- 截到 12K 字符够覆盖 head 部分（按重要性排序）
+
+## LLM 使用
+
+| 调用 | task_tag | Prompt | 输入 | 输出 |
+|------|----------|--------|------|------|
+| YoY diff | `risk_yoy_diff` | `prompts/risk_yoy_diff_v1.yaml` | ticker + company_name + 当年/上年 filing meta + 12K + 12K Risk Factors 文本 | `RiskYoYDiff` (Pydantic, 4 桶 + summary + confidence) |
+
+**单次成本**: ~24K input + ~1.5K output = **~$0.0035 DeepSeek / ~$0.10 GPT-4o**（管线最贵的单次调用）。
+
+## 失败模式与降级
+
+| 条件 | 行为 |
+|------|------|
+| `user_tier="free"` | emit `risk_yoy_diff_locked_card`, 返回 None |
+| `financials.cik` 缺失 | emit skipped, 返回 None |
+| LLM 未配置 | emit skipped, 返回 None |
+| current 或 prior 任一 fetch_10k 失败 | emit skipped, 返回 None |
+| 两年 Risk Factors 任一解析失败 | emit skipped, 返回 None |
+| 公司只有一份 10-K (新上市) | n_back=1 找不到 → emit skipped |
+| LLM 调用失败 | emit skipped, 返回 None |
+| LLM 输出引文不在源文本中 | 整条 RiskChange 丢弃, 其它继续 |
+| 4 桶全空 | 仍 emit ComponentEvent (前端显示 "no material changes") |
+| **下游影响** | `investment_thesis` 仍能跑；`risk_yoy_summary` 显示 "not available" |
+
+## 源文件
+
+| 文件 | 职责 |
+|------|------|
+| `backend/agents/nodes/risk_yoy_diff.py` | 节点入口 + RiskChange/RiskYoYDiff Pydantic + `_verify_change` / `_filter_changes` |
+| `backend/agents/nodes/_pro_gate.py` | tier 门控 helper |
+| `backend/agents/nodes/qualitative_analysis.py` | 共用 `_normalize` 和 `verify_quotes` |
+| `backend/services/tenk_parser.py` | `extract_risk_factors` / `truncate_head` |
+| `backend/services/sec_client.py` | `fetch_10k(cik, n_back=0)` + `fetch_10k(cik, n_back=1)` (共享 6-entry FIFO HTML 缓存) |
+| `backend/prompts/risk_yoy_diff_v1.yaml` | YoY diff prompt |
+
+## 与其他节点的关系
+
+- **依赖**: `fetch_sec_data` (cik); `qualitative_analysis` 不是硬依赖但顺序在前 (帮忙暖了 current 10-K HTML 缓存)
+- **消费者**: `investment_thesis` 通过 `_risk_yoy_summary()` 把 4 桶 diff 写入 thesis prompt
+
+## 前端组件
+
+| component_type | 组件 | 触发条件 |
+|----------------|------|----------|
+| `risk_yoy_diff_card` | `RiskYoYDiffCard` — 4 桶 2x2 网格；escalated/de_escalated 显示 prior↔current 并排引文；底部双年 SEC 链接 | 节点成功输出（即使 4 桶都空） |
+| `risk_yoy_diff_locked_card` | `ProLockedCard` (shared) — Pro 升级 CTA | `user_tier="free"` |
+
+## 相关 ADR
+
+- [009 — tier-gating-strategy](../decisions/009-tier-gating-strategy.md)
+- [006 — unified-llm-client](../decisions/006-unified-llm-client.md)

--- a/docs/nodes/11-moat-analysis.md
+++ b/docs/nodes/11-moat-analysis.md
@@ -1,0 +1,222 @@
+# Node 11: moat_analysis 🔒 Pro
+
+> 图位置: `risk_yoy_diff → moat_analysis → investment_thesis`
+
+## 职责
+
+按 Hamilton Helmer 「**7 Powers**」框架（Scale Economies / Network Effects / Counter-Positioning / Switching Costs / Branding / Cornered Resource / Process Power）给公司打分，每维 0-10 + 必须有 10-K Item 1 (Business) 中的逐字引文佐证。**不可核验的 score ≥3 自动 demote 到 0**（保留行结构便于 UI 一致性，但去掉无据宣称）。
+
+## 输入
+
+> **真相源**: `backend/models/agent_state.py` — `AnalysisState`
+
+### State 字段
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|:----:|------|
+| `financials` | `CompanyFinancials` | ✅ | → [Node 1 输出](01-fetch-sec-data.md#companyfinancials-结构体) |
+| `user_tier` | `str` | ✅ | `"free"` 短路 emit locked card |
+
+### 子字段访问
+
+| 访问路径 | 类型 | 必需 | 用途 |
+|----------|------|:----:|------|
+| `financials.cik` | `int` | ✅ | 拉 10-K Item 1 Business |
+| `financials.ticker` | `str` | ✅ | LLM prompt + 日志 |
+| `financials.entity_name` | `str` | ✅ | LLM prompt + ComponentEvent |
+
+### AAPL 示例 (输入子字段)
+
+```json
+{
+  "user_tier": "pro",
+  "financials": {"ticker": "AAPL", "entity_name": "Apple Inc.", "cik": 320193}
+}
+```
+
+---
+
+## 输出
+
+### State 更新
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `moat_result` | `dict \| None` | 7 powers 评分 + classification |
+| `reasoning_steps` | `list[str]` | 追加到推理链 |
+
+### `moat_result` 结构体
+
+> **源码**: `backend/agents/nodes/moat_analysis.py` line 280-296
+
+```python
+{
+    "ticker": str,
+    "filing_date": str,                      # ISO date, e.g. "2025-10-31"
+    "accession_number": str,
+    "filing_url": str,                       # SEC Archives 直链
+    "powers": list[MoatPower],               # 7 条, 一个 power 一行
+    "overall_moat_score": float,             # max(verified_scores), 1 位小数
+    "moat_classification": "wide" | "narrow" | "none",
+    "primary_powers": list[PowerName],       # 最多 3 个 score≥3 的最高分 powers
+    "thesis_one_liner": str,                 # 一句话护城河论点
+    "demoted_power_count": int,              # 引文核验失败被降到 0 的数量
+    "confidence": float,                     # [0, 1]
+    "parser_strategy": str,                  # extract_business 用的策略
+}
+```
+
+**`MoatPower` 子结构** (Pydantic):
+
+```python
+{
+    "power": "scale_economies|network_effects|counter_positioning|switching_costs|branding|cornered_resource|process_power",
+    "score": float,                          # [0, 10], 0 = 无证据 / 已被 demote
+    "rationale": str,                        # 1-2 句解释; demoted 时前缀 "[demoted] "
+    "evidence_quote": str | None,            # 已逐字核验, ≥40 chars; demoted 或 score<3 时 None
+}
+```
+
+**`overall_moat_score` 计算规则** (`_verify_and_demote` 后):
+
+```python
+overall = max(verified_scores)               # 不是平均；强项决定 moat 强度（Helmer 原话）
+classification = "wide"   if overall >= 7
+                "narrow" if 4 <= overall < 7
+                "none"   if overall < 4
+```
+
+### `_verify_and_demote` 行为
+
+| 情况 | 动作 |
+|------|------|
+| score ≥ 3 且 quote 在 source_text 中 | 保留 score 和 quote |
+| score ≥ 3 但 quote 不可核验 | **demote**: score → 0, quote → None, rationale 前缀 `[demoted]` |
+| score < 3 (无证据 / 弱) | 保留, quote 可为 None |
+
+`primary_powers` 在 demote 之后**重新计算**（取 verified score≥3 中最高 3 个）。
+
+### AAPL 示例 (实际抓出的真实 filing + LLM 模拟输出)
+
+```json
+{
+  "moat_result": {
+    "ticker": "AAPL",
+    "filing_date": "2025-10-31",
+    "accession_number": "0000320193-25-000079",
+    "filing_url": "https://www.sec.gov/Archives/edgar/data/320193/000032019325000079/aapl-20250927.htm",
+    "powers": [
+      {
+        "power": "branding",
+        "score": 9.0,
+        "rationale": "Apple brand commands premium pricing across multiple categories with sustained gross margin above industry average.",
+        "evidence_quote": "The Company designs, manufactures and markets smartphones, personal computers, tablets, wearables and accessories, and sells a variety of related services."
+      },
+      {
+        "power": "switching_costs",
+        "score": 7.5,
+        "rationale": "Tightly integrated ecosystem (iCloud, iMessage, Health) creates real friction for users to leave.",
+        "evidence_quote": "..."
+      },
+      {"power": "scale_economies", "score": 6.0, "rationale": "...", "evidence_quote": "..."},
+      {"power": "network_effects", "score": 5.0, "rationale": "...", "evidence_quote": "..."},
+      {"power": "process_power", "score": 4.0, "rationale": "...", "evidence_quote": "..."},
+      {"power": "cornered_resource", "score": 2.0, "rationale": "No specific evidence.", "evidence_quote": null},
+      {"power": "counter_positioning", "score": 1.0, "rationale": "Not a counter-positioned business.", "evidence_quote": null}
+    ],
+    "overall_moat_score": 9.0,
+    "moat_classification": "wide",
+    "primary_powers": ["branding", "switching_costs", "scale_economies"],
+    "thesis_one_liner": "Apple's dominant brand power, reinforced by ecosystem switching costs, defines a wide and durable moat.",
+    "demoted_power_count": 0,
+    "confidence": 0.78,
+    "parser_strategy": "strict_multi_ws"
+  }
+}
+```
+
+## 核心算法
+
+```
+1. is_pro_user(state) → False → emit moat_locked_card → return None
+2. is_llm_configured() → False → emit skipped → return None
+
+3. sec_client.fetch_10k(cik, n_back=0)
+   └── 通常命中缓存（qualitative_analysis 已暖过）
+
+4. extract_business(html) — Item 1 Business 段
+   └── 三层正则回退 (strict_multi_ws → loose → fallback)
+   └── 失败 → emit skipped → return None
+
+5. smart_truncate(text, 12_000) — 头 6K + 尾 6K + 中间标记
+
+6. LLMClient.complete_json("moat_analysis", response_model=MoatInsight)
+   └── 失败 → emit skipped → return None
+
+7. _verify_and_demote(insight.powers, source_text=section.text)
+   └── score ≥ 3 + quote 不可核验 → demote 到 0; rationale 加 [demoted]
+   └── score < 3 → 原样保留
+
+8. 用 verified_scores 重新计算 overall_moat_score = max(scores)
+9. 用 verified_scores 重新计算 primary_powers (top 3 of score ≥ 3)
+10. emit ComponentEvent("moat_analysis_card")
+```
+
+## 关键假设
+
+- **Helmer 的核心观点**：moat 强度由最强那个 power 决定（不是 7 个的平均），所以用 `max()` 而非平均
+- 大多数公司在大多数 power 上得分应该是 0-3（"absent" / "weak"）—— 7+ 的得分需要结构性证据
+- Item 1 Business 比 MD&A 更适合 moat 分析（业务模型 / 竞争定位 / 客户结构都在这里）
+- 12K 头尾截断保留 Company Background + Strategy / Distribution 部分（XBRL 已捕获财务，不需要重复）
+- LLM 容易在 "branding" / "network_effects" 上虚高 —— demote 机制是必要的
+- 同一份 10-K 一年内 moat 评分应该稳定（缓存命中后零额外 LLM 成本）
+
+## LLM 使用
+
+| 调用 | task_tag | Prompt | 输入 | 输出 |
+|------|----------|--------|------|------|
+| 7 Powers 评分 | `moat` | `prompts/moat_analysis_v1.yaml` | ticker + company_name + filing_date + accession + 12K Business 文本 | `MoatInsight` (Pydantic) |
+
+**单次成本**: ~3K input + ~1.5K output = **~$0.001 DeepSeek / ~$0.025 GPT-4o**。
+
+## 失败模式与降级
+
+| 条件 | 行为 |
+|------|------|
+| `user_tier="free"` | emit `moat_locked_card`, 返回 None |
+| `financials.cik` 缺失 | emit skipped, 返回 None |
+| LLM 未配置 | emit skipped, 返回 None |
+| `fetch_10k` 失败 | emit skipped, 返回 None |
+| `extract_business` 解析失败 (Item 1 找不到 / 太短) | emit skipped, 返回 None |
+| LLM 调用失败 | emit skipped, 返回 None |
+| LLM 输出引文不可核验 | 单条 power demote 到 0, 其它 power 不受影响 |
+| 全部 7 个 power 都 < 3 | 正常输出, classification="none", primary_powers=[] |
+| **下游影响** | `investment_thesis` 仍能跑；`moat_summary` 显示 "not available" |
+
+## 源文件
+
+| 文件 | 职责 |
+|------|------|
+| `backend/agents/nodes/moat_analysis.py` | 节点入口 + MoatPower/MoatInsight Pydantic + `_verify_and_demote` |
+| `backend/agents/nodes/_pro_gate.py` | tier 门控 helper |
+| `backend/agents/nodes/qualitative_analysis.py` | 共用 `_normalize` (smart-quote / 空白归一化) |
+| `backend/services/tenk_parser.py` | `extract_business` (3 层正则) + `smart_truncate` |
+| `backend/services/sec_client.py` | `fetch_10k(cik, n_back=0)` + 缓存 |
+| `backend/prompts/moat_analysis_v1.yaml` | 7 Powers 评分 prompt |
+
+## 与其他节点的关系
+
+- **依赖**: `fetch_sec_data` (cik); `qualitative_analysis` 不是硬依赖但已经把当年 10-K HTML 暖进缓存
+- **消费者**: `investment_thesis` 通过 `_moat_summary()` 把 classification + primary_powers + thesis_one_liner 写入 thesis prompt
+
+## 前端组件
+
+| component_type | 组件 | 触发条件 |
+|----------------|------|----------|
+| `moat_analysis_card` | `MoatAnalysisCard` — 7 power 渐变进度条 + primary badge + verbatim 引文 + overall = max | 节点成功输出 |
+| `moat_locked_card` | `ProLockedCard` (shared) — Pro 升级 CTA | `user_tier="free"` |
+
+## 相关 ADR
+
+- [009 — tier-gating-strategy](../decisions/009-tier-gating-strategy.md)
+- [006 — unified-llm-client](../decisions/006-unified-llm-client.md)

--- a/docs/nodes/12-investment-thesis.md
+++ b/docs/nodes/12-investment-thesis.md
@@ -1,0 +1,199 @@
+# Node 12: investment_thesis 🔒 Pro
+
+> 图位置: `moat_analysis → investment_thesis → logic_trace`
+
+## 职责
+
+汇总全部上游节点结果（DCF / 估值信号 / 财务健康 / 情绪 / 事件影响 / 定性分析 / YoY diff / 护城河），用 LLM 合成一份**结构化研报**：核心论点 + 看多 / 看空 / 风险点 + 操作建议 + 推荐评级 + 置信度。这是面向"客户能直接读"的最终交付物，也是 Pro 订阅最直接的价值锚点。
+
+## 输入
+
+> **真相源**: `backend/models/agent_state.py` — `AnalysisState`
+
+### State 字段（全部上游结果都会读）
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|:----:|------|
+| `financials` | `CompanyFinancials` | ✅ | 取 ticker + entity_name |
+| `user_tier` | `str` | ✅ | `"free"` 短路 emit locked card |
+| `strategy_result` | `dict` | ✅ | 没有 strategy 就不能写 thesis（margin of safety / signal 是论点骨架） |
+| `dcf_result` | `dict \| None` | ⬜ | DCF 假设 |
+| `relative_valuation_result` | `dict \| None` | ⬜ | 同业对比 |
+| `event_sentiment_result` | `dict \| None` | ⬜ | 新闻情绪 |
+| `event_impact_result` | `dict \| None` | ⬜ | 调整后的 DCF |
+| `qualitative_result` | `dict \| None` | ⬜ | MD&A + Risk Factors（[Node 9](09-qualitative-analysis.md)） |
+| `risk_yoy_diff_result` | `dict \| None` | ⬜ | YoY 风险变化（[Node 10](10-risk-yoy-diff.md)） |
+| `moat_result` | `dict \| None` | ⬜ | 7 Powers 评分（[Node 11](11-moat-analysis.md)） |
+
+### 子字段访问（被 `_build_variables` 读出格式化）
+
+| Helper 函数 | 读什么 | 写到 prompt 哪个 placeholder |
+|------------|--------|-----|
+| `_dcf_summary(dcf, event_impact)` | DCF + 事件调整后的 DCF | `{dcf_summary}` |
+| `_relative_valuation_summary(rel_val)` | peer P/E 折价 | `{relative_valuation_summary}` |
+| `_financial_health_summary(state)` | health_metrics + assessment | `{financial_health_summary}` |
+| `_event_sentiment_summary(sent)` | overall_score + key_events | `{event_sentiment_summary}` |
+| `_event_impact_summary(ei)` | parameter_adjustments | `{event_impact_summary}` |
+| `_qualitative_summary(qual)` | mdna.tone + 增长驱动 + 担忧 + risk_factors.top_risks + concentration | `{qualitative_summary}` |
+| `_risk_yoy_summary(yoy)` | 4 桶 diff 标题列表 | `{risk_yoy_summary}` |
+| `_moat_summary(moat)` | classification + primary_powers + power 评分 | `{moat_summary}` |
+
+每个 helper 都做 None-safe 降级（缺少上游 → 写 "not available"）。
+
+### AAPL 示例 (输入子字段, 摘要)
+
+```json
+{
+  "user_tier": "pro",
+  "financials": {"ticker": "AAPL", "entity_name": "Apple Inc."},
+  "strategy_result": {
+    "current_price": 273.43, "intrinsic_value": 169.41,
+    "margin_of_safety_pct": -61.4, "signal": "Overvalued",
+    "current_pe": 36.7, "pe_percentile": 80.0
+  },
+  "qualitative_result": {"mdna": {"tone": "cautious"}, "risk_factors": {"top_risks": [...]}},
+  "moat_result": {"moat_classification": "wide", "overall_moat_score": 9.0}
+}
+```
+
+---
+
+## 输出
+
+### State 更新
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `investment_thesis_result` | `dict \| None` | 结构化研报 |
+| `reasoning_steps` | `list[str]` | 追加到推理链 |
+
+### `investment_thesis_result` 结构体
+
+> **源码**: `backend/agents/nodes/investment_thesis.py` line 263-271 (`InvestmentThesis` Pydantic)
+
+```python
+{
+    "thesis_headline": str,                 # 一句话核心观点 (≤25 词)
+    "recommendation": "Strong Buy" | "Buy" | "Hold" | "Reduce" | "Sell",
+    "bull_points": list[str],               # 3-5 条看多
+    "bear_points": list[str],               # 3-5 条看空（可空）
+    "key_risks": list[str],                 # 3-5 条关键风险
+    "action_summary": str,                  # 2-3 句操作建议
+    "confidence": float,                    # [0, 1]
+}
+```
+
+**`recommendation` 选择规则** (prompt 内强制):
+
+| 推荐 | margin of safety 区间 | 附加条件 |
+|------|----------------------|---------|
+| Strong Buy | > 25% | + 财务健康 |
+| Buy | 10% — 25% | — |
+| Hold | -10% — 10% | — |
+| Reduce | -25% — -10% | — |
+| Sell | < -25% | OR 重大 red flags |
+
+### AAPL 示例 (LLM 模拟输出, 真实数据 + Overvalued 信号)
+
+```json
+{
+  "investment_thesis_result": {
+    "thesis_headline": "Wide-moat brand and ecosystem stickiness justify a premium, but a 61% gap between price and DCF intrinsic value makes near-term entry unattractive.",
+    "recommendation": "Reduce",
+    "bull_points": [
+      "Wide moat classification (overall 9.0/10) anchored in dominant brand power and ecosystem switching costs",
+      "Services revenue growth across App Store, cloud, and financial services drives recurring revenue",
+      "Net margin of 26.9% supports premium valuation in a maturing industry"
+    ],
+    "bear_points": [
+      "Current price $273.43 vs DCF intrinsic $169.41 implies -61.4% margin of safety",
+      "Current P/E 36.7 sits at 80th percentile of 10-year history (historically expensive)",
+      "Management tone in 2025 MD&A is cautious; flags FX and regulatory headwinds explicitly"
+    ],
+    "key_risks": [
+      "DMA / antitrust enforcement could force material business model changes",
+      "Concentrated supplier exposure in Asia (geopolitical risk)",
+      "Foreign-exchange headwinds compressing reported revenue"
+    ],
+    "action_summary": "Wait for a pullback to the suggested entry price of $144.00 (15% margin of safety). Existing holders may consider trimming exposure given current overvaluation and historically rich P/E.",
+    "confidence": 0.74
+  }
+}
+```
+
+## 核心算法
+
+```
+1. is_pro_user(state) → False → emit investment_thesis_locked_card → return None
+   (locked card 携带 strategy_result.signal + margin_of_safety_pct 作为免费预览)
+
+2. is_llm_configured() → False → emit skipped → return None
+
+3. financials 或 strategy_result 缺失 → emit skipped → return None
+   (没有 strategy 的 thesis 就是空中楼阁)
+
+4. variables = _build_variables(state)
+   ├── 主 strategy 数值 → format 成美元/百分比字符串
+   └── 8 个 helper 函数把上游 dict 格式化成 thesis prompt 的 placeholder
+
+5. LLMClient.complete_json("investment_thesis", response_model=InvestmentThesis,
+                            task_tag="thesis")
+   └── task_tag="thesis" 触发 narrative provider 路由（如配了 GPT-4o / Claude）
+
+6. emit ComponentEvent("investment_thesis_card", props={ticker, entity_name, ...thesis})
+```
+
+## 关键假设
+
+- **thesis 是综合产出，不是源数据**：所有数值已经在上游验证过；thesis 只做"用人话讲"的工作
+- 上游缺失某些字段是常态（FMP 402、Finnhub 空、10-K 解析失败），prompt 必须能处理 "not available"
+- `task_tag="thesis"` 是路由到 narrative provider 的关键钩子（[ADR 006](../decisions/006-unified-llm-client.md)）—— admin 可以单独把这一条切到 GPT-4o 而其它任务保持 DeepSeek
+- recommendation 严格按 margin of safety 区间映射，**不让 LLM 自由发挥** —— 防止"看多 narrative + Sell 推荐"这种自相矛盾
+- 免费用户能在 locked card 看到 `signal` + `margin_of_safety_pct`（preview），但看不到 thesis 内容 —— 是 Upgrade 的天然钩子
+
+## LLM 使用
+
+| 调用 | task_tag | Prompt | 输入 | 输出 |
+|------|----------|--------|------|------|
+| 投资论点合成 | `thesis` | `prompts/investment_thesis_v1.yaml` | ticker + 8 个 helper 输出的格式化字符串 | `InvestmentThesis` (Pydantic) |
+
+**单次成本**: ~2K input + ~1K output = **~$0.0008 DeepSeek / ~$0.02 GPT-4o**。
+
+`task_tag="thesis"` 路由到 narrative provider —— 如果 admin 配了 `AQ_LLM_NARRATIVE_*`，这个调用会走那个 provider 而非 primary。
+
+## 失败模式与降级
+
+| 条件 | 行为 |
+|------|------|
+| `user_tier="free"` | emit `investment_thesis_locked_card` (含 strategy preview), 返回 None |
+| `financials` 或 `strategy_result` 缺失 | emit skipped, 返回 None |
+| LLM 未配置 | emit skipped, 返回 None |
+| LLM 调用失败 (402 / parse / budget) | emit skipped + thinking event, 返回 None |
+| 上游 4 个 Pro 节点全部失败 (qualitative / yoy / moat 都 None) | 仍能跑 —— prompt 用 "not available" 占位 |
+| **下游影响** | `logic_trace` 不依赖 thesis, 正常完成 |
+
+## 源文件
+
+| 文件 | 职责 |
+|------|------|
+| `backend/agents/nodes/investment_thesis.py` | 节点入口 + InvestmentThesis Pydantic + 8 个 `_*_summary` helper |
+| `backend/agents/nodes/_pro_gate.py` | tier 门控 helper |
+| `backend/services/llm/client.py` | `LLMClient.complete_json` + `_select_provider("thesis")` 路由 |
+| `backend/prompts/investment_thesis_v1.yaml` | thesis 合成 prompt（recommendation 映射规则也在这里） |
+
+## 与其他节点的关系
+
+- **依赖**: `strategy` (硬依赖); `dcf_model` / `relative_valuation` / `event_sentiment` / `event_impact` / `qualitative_analysis` / `risk_yoy_diff` / `moat_analysis` (软依赖, 缺失时降级)
+- **消费者**: `logic_trace` 读 `investment_thesis_result.thesis_headline` 写入最终 verdict（如有）；前端 `strategy_dashboard` 旁边渲染 `investment_thesis_card`
+
+## 前端组件
+
+| component_type | 组件 | 触发条件 |
+|----------------|------|----------|
+| `investment_thesis_card` | `InvestmentThesisCard` — Bull/Bear/Risks 三栏 + recommendation 徽章 + confidence + action callout | 节点成功输出 |
+| `investment_thesis_locked_card` | `ProLockedCard` (shared) — 带 strategy.signal + margin_of_safety_pct 的免费预览 + Upgrade CTA | `user_tier="free"` |
+
+## 相关 ADR
+
+- [009 — tier-gating-strategy](../decisions/009-tier-gating-strategy.md)
+- [006 — unified-llm-client](../decisions/006-unified-llm-client.md)（特别是 narrative provider 路由）


### PR DESCRIPTION
Closes #5.

## Summary

PR #3 introduced the three-tier docs structure (ARCHITECTURE.md → `docs/nodes/` → `docs/decisions/`). PR #4 then appended Phase 1/2/3 detail to ARCHITECTURE.md §11-14 in the older "all in one file" style. This PR brings PR #4's content into the new structure.

## What's in this PR

**4 new node docs** (mirror format of `01-08`):
- `docs/nodes/09-qualitative-analysis.md` — 10-K MD&A + Risk Factors (Pro)
- `docs/nodes/10-risk-yoy-diff.md` — YoY risk diff with dual-quote verify (Pro)
- `docs/nodes/11-moat-analysis.md` — Hamilton Helmer 7 Powers scoring (Pro)
- `docs/nodes/12-investment-thesis.md` — synthesized research narrative (Pro)

**4 new ADRs** (mirror format of `001-005`):
- `docs/decisions/006-unified-llm-client.md` — single chokepoint pattern
- `docs/decisions/007-three-layer-cost-guardrails.md` — IP rate limit + per-IP budget + global budget
- `docs/decisions/008-pluggable-auth-providers.md` — three providers funnel into AuthService
- `docs/decisions/009-tier-gating-strategy.md` — gate at node entry vs route layer (with rationale)

**ARCHITECTURE.md cleanup**:
- §11-14 (~480 lines of detailed implementation) replaced with §10 "Beyond v0.4 — Phase 1/2/3 总览" (~150 lines)
- §2 directory tree: 8 nodes → 12 nodes, 5 ADRs → 9 ADRs (with 🆕 markers)
- Doc-map updated to include DEVELOPMENT.md and the new doc counts

## Diff stats

- ARCHITECTURE.md: 1264 → 944 lines (**-320, -25%**)
- 8 new files totalling ~2100 lines, each at the appropriate granularity (~200-280 for nodes, ~70-110 for ADRs)
- All cross-doc relative links verified to resolve

## Style consistency

Each new node doc follows the same template as `01-08`:
> 职责 → 输入 (state fields + sub-paths + AAPL example) → 输出 (state update + struct + AAPL example) → 核心算法 → 关键假设 → LLM 使用 → 失败模式与降级 → 源文件 → 与其他节点的关系 → 前端组件 → 相关 ADR

Each new ADR follows the same template as `001-005`:
> 背景 → 考虑的方案 (with ✓ on chosen) → 决策 → 后果 (正面 / 负面 / 未决问题)

Pro nodes are marked 🔒 in headers and section headings to make tier gating visually obvious.

## How to review

1. Read the doc-map table at the top of `ARCHITECTURE.md` (3 minutes — orients you)
2. Pick one node doc (e.g. `nodes/11-moat-analysis.md`) and one ADR (e.g. `decisions/006-unified-llm-client.md`) to verify they match the existing style and the actual code
3. Spot-check that `ARCHITECTURE.md §10` summaries point to the right detail files

🤖 Generated with [Claude Code](https://claude.com/claude-code)