### PR TITLE
feat(admin): runtime LLM provider switching (no restart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 | 版本 | 日期 | 类型 | 变更摘要 |
 |------|------|------|----------|
-| v0.7.1 | 2026-04-26 | docs | **文档体系重构（@Skyward666）**：ARCHITECTURE.md 拆分为三层文档体系（系统全景 + `docs/nodes/` 节点详情 + `docs/decisions/` 架构决策记录）。8 个核心节点文档全面重写（含 I/O 结构体定义 + NVDA 示例 + 失败模式）；5 个 ADR 记录关键架构决策。__注：本次新增的 v0.5/0.6/0.7 节点（qualitative_analysis / risk_yoy_diff / moat_analysis / investment_thesis）的 docs/nodes/ 文档将在 follow-up PR 中补齐__ |
+| v0.7.2 | 2026-04-28 | feat | **Admin 运行时切换 LLM provider**：`PATCH /api/admin/settings` 现支持 `llm_api_key` / `llm_base_url` / `llm_model` / `llm_narrative_*` 6 个字段。改动后 LLMClient singleton 自动失效，下次请求重建（不重启）。GET/PATCH/reset 响应中 api_key 自动 redacted（`***last4` 格式）。bad URL 拒绝在 PATCH 阶段，避免后续请求才发现 |
+| v0.7.1 | 2026-04-26 | docs | **文档体系重构（@Skyward666 + follow-up）**：ARCHITECTURE.md 拆分为三层文档体系（系统全景 + `docs/nodes/` 节点详情 + `docs/decisions/` 架构决策记录）。__PR #3__ 引入结构 + 8 个 v0.4 节点文档 + 5 个 ADR。__PR #6__ 跟进补齐 v0.5/0.6/0.7 内容：4 个 Pro 节点文档（09-12）+ 4 个 ADR（006-009）；ARCHITECTURE.md §11-14 缩为 §10 概览（-320 行）|
 | v0.7.0 | 2026-04-25 | feat | **认证 + 订阅分级（Phase 2）**：邮箱/密码 + Magic Link + Google OAuth 三种登录方式；PostgreSQL 持久化；JWT 会话；4 个 Pro 节点按 user.tier 门控（free 用户看到锁定预览卡）；admin 可手动升级用户为 Pro。新增 `services/auth/` 模块、Alembic 迁移、AuthProvider Context、登录/注册页 |
 | v0.6.0 | 2026-04-25 | feat | **5 个 LLM Pro 节点（Phase 3）**：投资论点生成器、10-K MD&A 定性分析、10-K Risk Factors 抽取、10-K YoY 风险变化对比、Hamilton Helmer 7 Powers 护城河评分。统一逐字引文核验防幻觉；分析管线从 8 节点扩至 12 节点 |
 | v0.5.0 | 2026-04-24 | feat | **LLM 基础设施 + 成本围栏（Phase 1）**：统一 LLMClient + Prompt YAML 库 + Provider 抽象 + Token 计费；BudgetGate（全局/per-IP 双闸熔断）+ IP 限流 + RuntimeSettings（admin 可热改阈值）+ `/api/admin/*` 接口（usage / settings / settings/reset） |
@@ -14,6 +15,75 @@
 | v0.3.0 | 2026-04-21 | feat | 消息面情绪修正：Finnhub 新闻 + 内部人情绪 → 综合评分 → 安全边际调整。新增 Finnhub 客户端、DeepSeek LLM 情绪分析、sentiment_card 组件 |
 | v0.2.0 | 2026-04-17 | feat | 相对估值（市场乘数法）：当前乘数 + 历史百分位 + 同业对比。新增 FMP API 客户端、relative_valuation_card 组件 |
 | v0.1.0 | 2026-04-17 | — | 初始版本：SEC EDGAR 数据获取、财务健康扫描、DCF 估值建模、买入策略、数据溯源、SSE + Generative UI |
+
+---
+
+## v0.7.2 — Admin 运行时切换 LLM provider
+
+**日期：** 2026-04-28
+
+### 概要
+
+把 LLM 的 provider / model / api_key 从「启动期 env 固定」升级为「admin 运行时可改」。
+admin `PATCH /api/admin/settings` 改完之后下次请求自动用新配置；不需重启进程；
+不影响 in-flight 请求；不重置 token 计费历史。
+
+### 用法
+
+```bash
+# 切到 OpenAI
+curl -X PATCH \
+  -H "Authorization: Bearer $AQ_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "llm_api_key": "sk-openai-xxx",
+    "llm_base_url": "https://api.openai.com/v1",
+    "llm_model": "gpt-4o-mini"
+  }' \
+  http://localhost:8000/api/admin/settings
+
+# 一键回 .env 默认
+curl -X POST -H "Authorization: Bearer $AQ_ADMIN_TOKEN" \
+  http://localhost:8000/api/admin/settings/reset
+
+# 单独切 thesis（task_tag）走高端模型，其它仍走 DeepSeek
+curl -X PATCH ... -d '{
+  "llm_narrative_api_key": "sk-openai-xxx",
+  "llm_narrative_base_url": "https://api.openai.com/v1",
+  "llm_narrative_model": "gpt-4o"
+}'
+```
+
+### 变更文件
+
+| 文件 | 变更 |
+|------|------|
+| `backend/services/runtime_settings.py` | `EffectiveSettings` 加 6 个 LLM 字段；`as_dict(redact=True)` 把 api_key 改成 `***last4`；新增 `redact_overrides`、`has_llm_overrides`、`LLM_PROVIDER_FIELDS` / `REDACTED_FIELDS` 常量；`_coerce` 验证 https URL |
+| `backend/services/llm/client.py` | 新增 `_effective_llm_config()`（override 优先，env fallback）+ `invalidate_llm_client()`；`_build_client` / `is_llm_configured` 改读 runtime |
+| `backend/services/llm/__init__.py` | 公开 `invalidate_llm_client` |
+| `backend/api/admin.py` | `SettingsPatch` 加 6 个字段；`patch_settings` 在 LLM 字段动了时调 `invalidate_llm_client`，applied echo 自动 redact 秘钥；`reset_settings` 同样在有 LLM override 时 invalidate；GET 响应过 `redact_overrides` |
+
+### 安全设计
+
+- secret 字段（`llm_api_key` / `llm_narrative_api_key`）在所有 admin 响应里都 redacted（`***last4` 或 `***`），秘钥**只能写不能读**
+- bad URL（非 https / 非 localhost）在 PATCH 阶段被 400 拒绝，避免后续 LLM 调用才发现
+- empty string PATCH = "remove override, fall back to env"（不是"清空配置"）
+- 紧急停 LLM 的正确方式：`PATCH llm_daily_budget_usd=0`（BudgetGate 立即拦截，所有节点降级），不是改 api_key
+
+### 已知限制
+
+- 多 worker 部署（`uvicorn --workers N`）下，admin PATCH 只影响接收该 PATCH 的 worker；其余 worker 仍用旧配置直到下次重启或自身收到 PATCH。本期为单实例 MVP 设计。Multi-worker 解决方案在 follow-up（Redis pub-sub 通知所有 worker invalidate）。
+- 没有"切换历史"审计日志。如果需要追溯"今天上午谁把 model 改成了 gpt-4o"，目前只能查 admin token 谁拿着。
+
+### 验证
+
+- 10 个单元断言（runtime_settings + client）
+- 7 个 HTTP E2E（GET 初态/PATCH/再 GET/bad URL/未知字段/reset/numeric-only）
+
+### 相关
+
+- 实现自 [ADR 006](docs/decisions/006-unified-llm-client.md) 「Future extension points」中的「Multi-Provider 路由表（admin 在 RuntimeSettings 里热改）」
+- 详细推演见 PR description
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -211,6 +211,37 @@ curl -X PATCH -H "Authorization: Bearer $TOKEN" \
   http://localhost:8000/api/admin/settings                          # raise to $20
 ```
 
+### Switching LLM provider at runtime (since v0.7.2)
+
+The same admin endpoint can change `llm_api_key` / `llm_base_url` /
+`llm_model` (and the narrative-tier counterparts) without restarting:
+
+```bash
+# Switch the whole stack from DeepSeek to OpenAI
+curl -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "llm_api_key": "sk-openai-xxx",
+    "llm_base_url": "https://api.openai.com/v1",
+    "llm_model": "gpt-4o-mini"
+  }' \
+  http://localhost:8000/api/admin/settings
+
+# Roll everything back to .env defaults
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/admin/settings/reset
+```
+
+The next request rebuilds the LLMClient singleton with the new config; the
+shared httpx connection pool is preserved. API keys are auto-redacted in
+all admin GET/PATCH responses (`***last4`). Bad URLs are rejected at PATCH
+time, not at request time. Use `llm_daily_budget_usd: 0` as a kill switch
+rather than blanking the api_key (since blanks fall back to env).
+
+> Multi-worker note: when running under `uvicorn --workers N`, the PATCH
+> only updates the worker that received it. Single-instance deployment is
+> the assumption today; Redis pub-sub broadcast is a follow-up.
+
 ---
 
 ## 10. Troubleshooting

--- a/backend/backend/api/admin.py
+++ b/backend/backend/api/admin.py
@@ -18,9 +18,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.config import settings
 from backend.services.auth import AuthError, AuthService
 from backend.services.db import get_session, is_db_configured
-from backend.services.llm import get_accounting_store
+from backend.services.llm import get_accounting_store, invalidate_llm_client
 from backend.services.rate_limit import get_rate_limiter
-from backend.services.runtime_settings import get_runtime_settings
+from backend.services.runtime_settings import (
+    LLM_PROVIDER_FIELDS,
+    REDACTED_FIELDS,
+    get_runtime_settings,
+    redact_overrides,
+)
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -45,22 +50,51 @@ def require_admin(
 
 
 class SettingsPatch(BaseModel):
-    """Body for PATCH /api/admin/settings. All fields optional."""
+    """Body for PATCH /api/admin/settings. All fields optional.
+
+    Fields fall into two groups:
+
+    - **Numeric guardrails** (budget caps, rate limits): take effect on the
+      next read.
+    - **LLM provider config**: a change to any of these triggers
+      ``invalidate_llm_client()`` so the cached LLMClient singleton is
+      rebuilt with the new config on the next request.
+
+    Empty string for an LLM field == "remove override; fall back to env".
+    To roll back ALL overrides at once, use ``POST /settings/reset``.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
+    # Numeric guardrails
     llm_daily_budget_usd: float | None = None
     llm_per_ip_daily_budget_usd: float | None = None
     rate_limit_analyze_per_ip_day: int | None = None
     rate_limit_recalculate_per_ip_day: int | None = None
+
+    # LLM provider config (admin-overridable at runtime)
+    llm_api_key: str | None = None
+    llm_base_url: str | None = None
+    llm_model: str | None = None
+    llm_narrative_api_key: str | None = None
+    llm_narrative_base_url: str | None = None
+    llm_narrative_model: str | None = None
+
+
+def _redact_applied(applied: dict[str, Any]) -> dict[str, Any]:
+    """Mask secret values in the patch echo so logs/responses don't leak keys."""
+    return {
+        k: ("***" if k in REDACTED_FIELDS and v else v)
+        for k, v in applied.items()
+    }
 
 
 @router.get("/settings")
 def get_settings(_: None = Depends(require_admin)) -> dict[str, Any]:
     rt = get_runtime_settings()
     return {
-        "effective": rt.snapshot().as_dict(),
-        "overrides": rt.overrides(),
+        "effective": rt.snapshot().as_dict(redact=True),
+        "overrides": redact_overrides(rt.overrides()),
     }
 
 
@@ -76,13 +110,35 @@ def patch_settings(
         effective = get_runtime_settings().update(non_null)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    return {"effective": effective.as_dict(), "applied": non_null}
+
+    # Provider config changed → drop the cached LLMClient so the next
+    # request rebuilds with the new config. httpx connection pool stays
+    # alive (it has no host affinity beyond DNS caching).
+    llm_changed = bool(non_null.keys() & LLM_PROVIDER_FIELDS)
+    if llm_changed:
+        invalidate_llm_client()
+
+    return {
+        "effective": effective.as_dict(redact=True),
+        "applied": _redact_applied(non_null),
+        "llm_client_invalidated": llm_changed,
+    }
 
 
 @router.post("/settings/reset")
 def reset_settings(_: None = Depends(require_admin)) -> dict[str, Any]:
-    effective = get_runtime_settings().reset()
-    return {"effective": effective.as_dict(), "overrides": {}}
+    rt = get_runtime_settings()
+    had_llm = rt.has_llm_overrides()
+    effective = rt.reset()
+    # If we just dropped any LLM override, the next request must observe the
+    # env-based config — invalidate the singleton.
+    if had_llm:
+        invalidate_llm_client()
+    return {
+        "effective": effective.as_dict(redact=True),
+        "overrides": {},
+        "llm_client_invalidated": had_llm,
+    }
 
 
 class TierPatch(BaseModel):

--- a/backend/backend/services/llm/__init__.py
+++ b/backend/backend/services/llm/__init__.py
@@ -12,6 +12,7 @@ from .client import (
     close_llm_client,
     get_accounting_store,
     get_llm_client,
+    invalidate_llm_client,
     is_llm_configured,
 )
 from .errors import (
@@ -37,6 +38,7 @@ __all__ = [
     "close_llm_client",
     "get_accounting_store",
     "get_llm_client",
+    "invalidate_llm_client",
     "is_llm_configured",
     "sanitize_list",
     "sanitize_text",

--- a/backend/backend/services/llm/client.py
+++ b/backend/backend/services/llm/client.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ValidationError
 
 from backend.config import settings
 from backend.services.request_context import current_client_ip
+from backend.services.runtime_settings import get_runtime_settings
 
 from .accounting import AccountingStore
 from .budget import BudgetGate
@@ -235,27 +236,58 @@ def get_accounting_store() -> AccountingStore:
     return _accounting_store
 
 
+def _resolve(override: str, env_value: str) -> str:
+    """Override-with-env-fallback. Empty override = use env."""
+    return override if override else env_value
+
+
+def _effective_llm_config() -> dict[str, str]:
+    """Compute the LLM provider config in effect right now.
+
+    Override (RuntimeSettings, set by admin PATCH) wins over env. Empty
+    override falls back to env. This is the single source of truth read by
+    both ``_build_client`` and ``is_llm_configured``.
+    """
+    rt = get_runtime_settings().snapshot()
+    return {
+        "api_key": _resolve(rt.llm_api_key, settings.llm_api_key),
+        "base_url": _resolve(rt.llm_base_url, settings.llm_base_url),
+        "model": _resolve(rt.llm_model, settings.llm_model) or "deepseek-chat",
+        "narrative_api_key": _resolve(
+            rt.llm_narrative_api_key, settings.llm_narrative_api_key,
+        ),
+        "narrative_base_url": _resolve(
+            rt.llm_narrative_base_url, settings.llm_narrative_base_url,
+        ),
+        "narrative_model": _resolve(
+            rt.llm_narrative_model, settings.llm_narrative_model,
+        ),
+    }
+
+
 def _build_client() -> LLMClient:
-    if not settings.llm_api_key or not settings.llm_base_url:
+    cfg = _effective_llm_config()
+    if not cfg["api_key"] or not cfg["base_url"]:
         raise LLMConfigError(
-            "LLM not configured: AQ_LLM_API_KEY and AQ_LLM_BASE_URL must be set"
+            "LLM not configured: AQ_LLM_API_KEY and AQ_LLM_BASE_URL must be set "
+            "(or override via PATCH /api/admin/settings)"
         )
 
     http_client = _get_http_client()
     primary = OpenAICompatibleProvider(
         name="primary",
-        api_key=settings.llm_api_key,
-        base_url=settings.llm_base_url,
-        model=settings.llm_model or "deepseek-chat",
+        api_key=cfg["api_key"],
+        base_url=cfg["base_url"],
+        model=cfg["model"],
         http_client=http_client,
     )
     narrative: Provider | None = None
-    if settings.llm_narrative_api_key and settings.llm_narrative_base_url:
+    if cfg["narrative_api_key"] and cfg["narrative_base_url"]:
         narrative = OpenAICompatibleProvider(
             name="narrative",
-            api_key=settings.llm_narrative_api_key,
-            base_url=settings.llm_narrative_base_url,
-            model=settings.llm_narrative_model or settings.llm_model or "deepseek-chat",
+            api_key=cfg["narrative_api_key"],
+            base_url=cfg["narrative_base_url"],
+            model=cfg["narrative_model"] or cfg["model"],
             http_client=http_client,
         )
 
@@ -282,7 +314,24 @@ def get_llm_client() -> LLMClient:
 
 
 def is_llm_configured() -> bool:
-    return bool(settings.llm_api_key and settings.llm_base_url)
+    """True iff there is a usable api_key + base_url after applying overrides."""
+    cfg = _effective_llm_config()
+    return bool(cfg["api_key"] and cfg["base_url"])
+
+
+def invalidate_llm_client() -> None:
+    """Drop the cached ``LLMClient`` so the next ``get_llm_client`` rebuilds.
+
+    Used by the admin handler after PATCHing LLM provider fields. The shared
+    httpx connection pool (``_http_client``) is NOT closed — switching to a
+    different ``base_url`` just opens new connections to the new host on the
+    same pool. Accounting state is preserved (so spend history survives).
+
+    In-flight requests using the old client continue to completion; only
+    subsequent ``get_llm_client()`` calls observe the change.
+    """
+    global _llm_client
+    _llm_client = None
 
 
 async def close_llm_client() -> None:

--- a/backend/backend/services/runtime_settings.py
+++ b/backend/backend/services/runtime_settings.py
@@ -5,6 +5,18 @@ admin API can override them at runtime through ``RuntimeSettings.update``;
 overrides live in memory and reset on process restart. Everything read during
 request handling should come through ``get_runtime_settings()`` instead of
 ``settings`` directly, so admin changes take effect without a restart.
+
+Two classes of fields are managed here:
+
+1. **Numeric guardrails** (budget caps, rate limits) — admin can change these
+   freely, no side effects beyond the next read.
+2. **LLM provider config** (api_key / base_url / model for primary + narrative)
+   — admin changes require invalidating the cached ``LLMClient`` singleton so
+   the next request rebuilds with the new config. The admin handler does
+   that explicitly via ``invalidate_llm_client()`` (see ``services.llm.client``).
+
+Secret fields (api_key) are always redacted in admin GET responses; see
+``EffectiveSettings.as_dict(redact=...)`` and the ``REDACTED_FIELDS`` set.
 """
 
 from __future__ import annotations
@@ -16,12 +28,46 @@ from typing import Any
 from backend.config import settings
 
 
-_ALLOWED_FIELDS: set[str] = {
+# Numeric / non-secret fields. Admin PATCH validates as float / int / >=0.
+_NUMERIC_FIELDS: set[str] = {
     "llm_daily_budget_usd",
     "llm_per_ip_daily_budget_usd",
     "rate_limit_analyze_per_ip_day",
     "rate_limit_recalculate_per_ip_day",
 }
+
+# LLM provider config — string fields. Admin PATCH stores raw string.
+# Empty string acts as "no override; fall back to env" in ``_build_client``.
+_LLM_STRING_FIELDS: set[str] = {
+    "llm_api_key",
+    "llm_base_url",
+    "llm_model",
+    "llm_narrative_api_key",
+    "llm_narrative_base_url",
+    "llm_narrative_model",
+}
+
+# Subset of the above that should be masked in admin responses.
+REDACTED_FIELDS: frozenset[str] = frozenset({
+    "llm_api_key",
+    "llm_narrative_api_key",
+})
+
+# Subset that triggers an LLMClient rebuild when changed.
+LLM_PROVIDER_FIELDS: frozenset[str] = frozenset(_LLM_STRING_FIELDS)
+
+_ALLOWED_FIELDS: set[str] = _NUMERIC_FIELDS | _LLM_STRING_FIELDS
+
+
+def _redact(value: str) -> str:
+    """Return a masked form of *value* for admin GET responses."""
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "***"
+    # Last 4 chars help admin confirm "yes that's the right key" without
+    # actually exposing the secret.
+    return f"***{value[-4:]}"
 
 
 @dataclass
@@ -32,14 +78,43 @@ class EffectiveSettings:
     llm_per_ip_daily_budget_usd: float
     rate_limit_analyze_per_ip_day: int
     rate_limit_recalculate_per_ip_day: int
+    # LLM provider config (string fields; "" means no override → use env)
+    llm_api_key: str
+    llm_base_url: str
+    llm_model: str
+    llm_narrative_api_key: str
+    llm_narrative_base_url: str
+    llm_narrative_model: str
 
-    def as_dict(self) -> dict[str, Any]:
-        return {
+    def as_dict(self, *, redact: bool = False) -> dict[str, Any]:
+        d: dict[str, Any] = {
             "llm_daily_budget_usd": self.llm_daily_budget_usd,
             "llm_per_ip_daily_budget_usd": self.llm_per_ip_daily_budget_usd,
             "rate_limit_analyze_per_ip_day": self.rate_limit_analyze_per_ip_day,
             "rate_limit_recalculate_per_ip_day": self.rate_limit_recalculate_per_ip_day,
+            "llm_api_key": self.llm_api_key,
+            "llm_base_url": self.llm_base_url,
+            "llm_model": self.llm_model,
+            "llm_narrative_api_key": self.llm_narrative_api_key,
+            "llm_narrative_base_url": self.llm_narrative_base_url,
+            "llm_narrative_model": self.llm_narrative_model,
         }
+        if redact:
+            for k in REDACTED_FIELDS:
+                if d.get(k):
+                    d[k] = _redact(str(d[k]))
+        return d
+
+
+def redact_overrides(overrides: dict[str, Any]) -> dict[str, Any]:
+    """Apply secret redaction to a raw overrides dict (for admin GET)."""
+    out: dict[str, Any] = {}
+    for k, v in overrides.items():
+        if k in REDACTED_FIELDS and isinstance(v, str) and v:
+            out[k] = _redact(v)
+        else:
+            out[k] = v
+    return out
 
 
 class RuntimeSettings:
@@ -50,6 +125,7 @@ class RuntimeSettings:
         self._overrides: dict[str, Any] = {}
 
     def _env_value(self, key: str) -> Any:
+        # Field names match the Settings attributes one-to-one.
         return getattr(settings, key)
 
     def snapshot(self) -> EffectiveSettings:
@@ -81,9 +157,17 @@ class RuntimeSettings:
         return self.snapshot()
 
     def overrides(self) -> dict[str, Any]:
-        """Return a copy of the current override dict (for admin introspection)."""
+        """Return a copy of the current override dict (for admin introspection).
+
+        Use ``redact_overrides`` before exposing to admin clients.
+        """
         with self._lock:
             return dict(self._overrides)
+
+    def has_llm_overrides(self) -> bool:
+        """True iff any LLM provider field is currently overridden."""
+        with self._lock:
+            return bool(self._overrides.keys() & LLM_PROVIDER_FIELDS)
 
 
 def _coerce(key: str, value: Any) -> Any:
@@ -97,6 +181,18 @@ def _coerce(key: str, value: Any) -> Any:
         if fv < 0:
             raise ValueError(f"{key} must be >= 0")
         return fv
+    if key in _LLM_STRING_FIELDS:
+        if value is None:
+            return ""
+        sv = str(value).strip()
+        # Light sanity-check on URL fields. We do NOT verify reachability —
+        # admin is trusted; bad URLs surface as LLMProviderError on next call.
+        if key in {"llm_base_url", "llm_narrative_base_url"} and sv:
+            if not (sv.startswith("https://") or sv.startswith("http://localhost") or sv.startswith("http://127.0.0.1")):
+                raise ValueError(
+                    f"{key} must use https:// (or http://localhost / http://127.0.0.1)"
+                )
+        return sv
     return value
 
 


### PR DESCRIPTION
## Summary

Admin can now switch LLM provider / model / api_key via `PATCH /api/admin/settings`; the next request picks up the new config without a restart.

This is the L1 work referenced in [ADR 006](docs/decisions/006-unified-llm-client.md) "Future extension points → Multi-Provider 路由表（admin 在 RuntimeSettings 里热改）".

## Why now

- DeepSeek balance is 0; quickest workaround was `vim .env && uvicorn --reload` — fine for solo dev, awkward when you have a co-developer or a deploy. This PR makes it a 2-second curl.
- We can A/B different models in production with no downtime.
- Sets up for future per-user LLM preferences (L3) — same code path, just `user.preferences` becomes another override layer.

## Behavior

```bash
# Switch DeepSeek → OpenAI
curl -X PATCH \
  -H "Authorization: Bearer $AQ_ADMIN_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "llm_api_key": "sk-openai-xxx",
    "llm_base_url": "https://api.openai.com/v1",
    "llm_model": "gpt-4o-mini"
  }' \
  http://localhost:8000/api/admin/settings

# Response (api_key redacted):
# {"effective": {"llm_api_key": "***-xxx", ...},
#  "applied": {"llm_api_key": "***", ...},
#  "llm_client_invalidated": true}

# Roll back to .env
curl -X POST -H "Authorization: Bearer $AQ_ADMIN_TOKEN" \
  http://localhost:8000/api/admin/settings/reset
```

## Files changed (6)

| File | Change |
|------|--------|
| `services/runtime_settings.py` | +6 LLM string fields; `as_dict(redact=True)` masks secrets; `redact_overrides`, `has_llm_overrides`, `LLM_PROVIDER_FIELDS`, `REDACTED_FIELDS` exports; URL validator |
| `services/llm/client.py` | `_effective_llm_config()` (override > env > fallback); `invalidate_llm_client()` (drops singleton, keeps httpx pool); `_build_client` + `is_llm_configured` migrated |
| `services/llm/__init__.py` | Re-export `invalidate_llm_client` |
| `api/admin.py` | `SettingsPatch` +6 fields; PATCH/reset call `invalidate_llm_client()` when LLM fields changed; GET/PATCH responses redacted |
| `CHANGELOG.md` | New v0.7.2 entry + retroactive v0.7.1 row update mentioning PR #6 |
| `DEVELOPMENT.md` | New "Switching LLM provider at runtime" subsection |

Net diff: **+328 / -24**.

## Security

- API keys never appear in plain text in any admin response (`***last4` format; `***` for short keys ≤ 8 chars)
- Bad URLs rejected at PATCH time (400) instead of being discovered at the next LLM call
- Empty string for an LLM field = "remove override, fall back to env" (NOT "blank the config"). The documented kill switch is `llm_daily_budget_usd: 0`.

## Verification

**10 unit assertions** (`runtime_settings` + `llm.client`):
- Accept new fields / reject bad URL / redaction format / override > env / env fallback / `is_llm_configured` tracks runtime / `invalidate_llm_client` nullifies / `has_llm_overrides` discriminates / `redact_overrides` masks correctly

**7 HTTP E2E** (against running uvicorn):
- Initial GET (real `.env` key shown as `***ac33`)
- PATCH provider config → `llm_client_invalidated: true`
- Re-GET → overrides redacted
- Bad URL → 400 with clear message
- Unknown field → 422 from Pydantic
- Reset → invalidates client (because there were LLM overrides)
- Numeric-only PATCH (`llm_daily_budget_usd: 7.5`) → `llm_client_invalidated: false` ✓ correctly distinguishes

## Known limitation

**Multi-worker deployment** (`uvicorn --workers N`): admin PATCH only affects the worker that received it. The other workers stay on old config until they restart or receive their own PATCH. Single-instance is the assumption today; Redis pub-sub broadcast is a follow-up. Documented in CHANGELOG and code comments.

## How to review

1. Read [ADR 006](docs/decisions/006-unified-llm-client.md) section "Future extension points" — this PR ticks the first bullet
2. Skim `services/llm/client.py` — `_effective_llm_config` and `invalidate_llm_client` are the heart
3. Skim `api/admin.py` `patch_settings` / `reset_settings` — see how LLM-changed detection drives the invalidation
4. Try locally:
   ```bash
   git checkout feature/admin-runtime-llm-config
   make backend  # in one terminal
   # in another:
   curl -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/admin/settings | jq
   ```

## Follow-ups (not in this PR)

- L3: per-user LLM preferences (Pro feature) — `users.preferences` JSONB column + `user_tier`-aware override layer
- L4: BYOK (Bring Your Own Key) for enterprise tier
- Multi-worker config sync (Redis pub-sub)
- "Switch history" audit log (who changed what when)

🤖 Generated with [Claude Code](https://claude.com/claude-code)