### PR TITLE
feat(dcf): real beta + net debt adjustment + 4% WACC floor

### DIFF
--- a/backend/backend/agents/nodes/dcf_model.py
+++ b/backend/backend/agents/nodes/dcf_model.py
@@ -32,24 +32,33 @@ def _estimate_wacc(
     debt: float | None,
     equity: float | None,
     interest_expense: float | None,
+    market_cap: float | None = None,
     risk_free_rate: float = 0.045,
     equity_risk_premium: float = 0.055,
     beta: float = 1.2,
     tax_rate: float = 0.21,
 ) -> float:
-    """Estimate WACC from available data. Falls back to reasonable defaults."""
+    """Estimate WACC from available data. Falls back to reasonable defaults.
+
+    Negative book equity (heavy buyback companies like MCD) → use ``market_cap``
+    as the equity weight if provided.
+    """
     cost_of_equity = risk_free_rate + beta * equity_risk_premium
 
-    if debt and equity and interest_expense and debt > 0:
+    # Negative/zero book equity → fall back to market cap for the equity weight
+    if equity is not None and equity <= 0 and market_cap and market_cap > 0:
+        equity = market_cap
+
+    if debt and equity and equity > 0 and interest_expense and debt > 0:
         cost_of_debt = abs(interest_expense) / debt
         total_capital = debt + equity
         wacc = (
             (equity / total_capital) * cost_of_equity
             + (debt / total_capital) * cost_of_debt * (1 - tax_rate)
         )
-        return max(wacc, 0.06)  # floor at 6%
+        return max(wacc, 0.04)  # floor at 4% (low for defensive low-beta names)
 
-    return cost_of_equity  # fallback: all-equity
+    return max(cost_of_equity, 0.04)
 
 
 def compute_dcf(
@@ -59,8 +68,15 @@ def compute_dcf(
     discount_rate: float,
     projection_years: int = 10,
     shares_outstanding: float | None = None,
+    cash: float | None = None,
+    total_debt: float | None = None,
 ) -> dict[str, Any]:
-    """Run the 2-stage DCF model."""
+    """Run the 2-stage DCF model.
+
+    If both ``cash`` and ``total_debt`` are provided, applies net debt
+    adjustment: per-share = (EV + cash − debt) / shares. Otherwise falls
+    back to EV / shares (legacy behavior, ignores capital structure).
+    """
     projected_fcf: list[dict[str, Any]] = []
     high_growth_years = projection_years // 2
 
@@ -97,12 +113,19 @@ def compute_dcf(
     pv_fcf_sum = sum(p["present_value"] for p in projected_fcf)
     enterprise_value = pv_fcf_sum + terminal_pv
 
+    # Equity value with net debt adjustment when capital-structure data is available
+    if cash is not None and total_debt is not None:
+        equity_value = enterprise_value + cash - total_debt
+    else:
+        equity_value = enterprise_value  # legacy: no net debt adj
+
     result = {
         "projected_fcf": projected_fcf,
         "terminal_value": round(terminal_value, 2),
         "terminal_pv": round(terminal_pv, 2),
         "pv_fcf_sum": round(pv_fcf_sum, 2),
         "enterprise_value": round(enterprise_value, 2),
+        "equity_value": round(equity_value, 2),
         "intrinsic_value_per_share": None,
         "assumptions": {
             "growth_rate": round(growth_rate * 100, 2),
@@ -115,7 +138,7 @@ def compute_dcf(
 
     if shares_outstanding and shares_outstanding > 0:
         result["intrinsic_value_per_share"] = round(
-            enterprise_value / shares_outstanding, 2
+            equity_value / shares_outstanding, 2
         )
 
     return result
@@ -132,8 +155,10 @@ async def dcf_node(
         ).model_dump())
         return {"dcf_result": None, "reasoning_steps": ["ERROR: No financial data for DCF"]}
 
+    market_profile = state.get("market_profile") or {}
+
     try:
-        return _run_dcf(financials, writer)
+        return _run_dcf(financials, writer, market_profile)
     except Exception as e:
         logger.exception("DCF modeling failed for %s", financials.ticker)
         writer(ErrorEvent(
@@ -143,7 +168,9 @@ async def dcf_node(
         return {"dcf_result": None, "reasoning_steps": [f"ERROR: DCF failed - {e}"]}
 
 
-def _run_dcf(financials: Any, writer: StreamWriter) -> dict[str, Any]:
+def _run_dcf(
+    financials: Any, writer: StreamWriter, market_profile: dict[str, Any] | None = None
+) -> dict[str, Any]:
     writer(AgentThinkingEvent(
         node="dynamic_dcf",
         content="Building DCF model from historical free cash flow...",
@@ -187,31 +214,43 @@ def _run_dcf(financials: Any, writer: StreamWriter) -> dict[str, Any]:
         content=f"FCF growth rate: {growth_rate * 100:.1f}% (3yr CAGR: {growth_3yr * 100:.1f}% weighted with 5yr)" if growth_3yr else f"FCF growth rate: {growth_rate * 100:.1f}%",
     ).model_dump())
 
-    # Estimate WACC
+    # Estimate WACC — uses live beta from market_profile when available
     debt = financials.long_term_debt[-1].value if financials.long_term_debt else None
     equity = financials.stockholders_equity[-1].value if financials.stockholders_equity else None
     interest = financials.interest_expense[-1].value if financials.interest_expense else None
+    cash = financials.cash_and_equivalents[-1].value if financials.cash_and_equivalents else None
 
-    discount_rate = _estimate_wacc(debt, equity, interest)
+    profile = market_profile or {}
+    beta = profile.get("beta") or 1.2  # fallback to legacy default
+    market_cap = profile.get("market_cap")
+
+    discount_rate = _estimate_wacc(
+        debt, equity, interest, market_cap=market_cap, beta=beta
+    )
     terminal_growth = 0.03
 
-    reasoning.append(f"WACC (discount rate): {discount_rate * 100:.1f}%")
+    reasoning.append(
+        f"WACC (discount rate): {discount_rate * 100:.1f}% (beta={beta:.2f})"
+    )
 
     writer(AgentThinkingEvent(
         node="dynamic_dcf",
-        content=f"Estimated WACC: {discount_rate * 100:.1f}%. Terminal growth: {terminal_growth * 100:.1f}%.",
+        content=f"Estimated WACC: {discount_rate * 100:.1f}% (beta={beta:.2f}). "
+                f"Terminal growth: {terminal_growth * 100:.1f}%.",
     ).model_dump())
 
     # Shares outstanding
     shares = financials.diluted_shares[-1].value if financials.diluted_shares else None
 
-    # Run DCF
+    # Run DCF (with net debt adjustment when cash + debt available)
     dcf_result = compute_dcf(
         latest_fcf=latest_fcf,
         growth_rate=growth_rate,
         terminal_growth_rate=terminal_growth,
         discount_rate=discount_rate,
         shares_outstanding=shares,
+        cash=cash,
+        total_debt=debt,
     )
 
     if dcf_result["intrinsic_value_per_share"]:

--- a/backend/backend/agents/nodes/dcf_model.py
+++ b/backend/backend/agents/nodes/dcf_model.py
@@ -45,15 +45,33 @@ def _estimate_wacc(
     """
     cost_of_equity = risk_free_rate + beta * equity_risk_premium
 
-    # Negative/zero book equity → fall back to market cap for the equity weight
-    if equity is not None and equity <= 0 and market_cap and market_cap > 0:
-        equity = market_cap
+    # Choose what to use for the equity-side weight in WACC. When book equity
+    # is non-positive (heavy-buyback names like MCD whose retained-earnings
+    # column went negative) book equity is meaningless as a capital-structure
+    # proxy; fall back to market cap if available. We compute a separate
+    # variable so the original ``equity`` argument (book equity) is not
+    # mutated — readers downstream shouldn't have to remember which one this
+    # is.
+    equity_weight = equity
+    if (
+        equity_weight is not None
+        and equity_weight <= 0
+        and market_cap
+        and market_cap > 0
+    ):
+        equity_weight = market_cap
 
-    if debt and equity and equity > 0 and interest_expense and debt > 0:
+    if (
+        debt
+        and equity_weight
+        and equity_weight > 0
+        and interest_expense
+        and debt > 0
+    ):
         cost_of_debt = abs(interest_expense) / debt
-        total_capital = debt + equity
+        total_capital = debt + equity_weight
         wacc = (
-            (equity / total_capital) * cost_of_equity
+            (equity_weight / total_capital) * cost_of_equity
             + (debt / total_capital) * cost_of_debt * (1 - tax_rate)
         )
         return max(wacc, 0.04)  # floor at 4% (low for defensive low-beta names)
@@ -69,13 +87,22 @@ def compute_dcf(
     projection_years: int = 10,
     shares_outstanding: float | None = None,
     cash: float | None = None,
-    total_debt: float | None = None,
+    long_term_debt: float | None = None,
 ) -> dict[str, Any]:
     """Run the 2-stage DCF model.
 
-    If both ``cash`` and ``total_debt`` are provided, applies net debt
-    adjustment: per-share = (EV + cash − debt) / shares. Otherwise falls
-    back to EV / shares (legacy behavior, ignores capital structure).
+    If both ``cash`` and ``long_term_debt`` are provided, applies a partial
+    net-debt adjustment: per-share = (EV + cash − long_term_debt) / shares.
+    Otherwise falls back to EV / shares (legacy behavior, ignores capital
+    structure).
+
+    NOTE — this is **long-term** debt only, not full total debt. The current
+    SEC tag map exposes ``long_term_debt`` but does not yet aggregate
+    short-term borrowings, commercial paper, current portion of long-term
+    debt, or operating lease liabilities. For companies that lean heavily on
+    those, equity value is currently slightly overstated. A follow-up will
+    extend the SEC ingestion to a true total-debt field; until then the
+    parameter name reflects what we actually subtract.
     """
     projected_fcf: list[dict[str, Any]] = []
     high_growth_years = projection_years // 2
@@ -113,9 +140,10 @@ def compute_dcf(
     pv_fcf_sum = sum(p["present_value"] for p in projected_fcf)
     enterprise_value = pv_fcf_sum + terminal_pv
 
-    # Equity value with net debt adjustment when capital-structure data is available
-    if cash is not None and total_debt is not None:
-        equity_value = enterprise_value + cash - total_debt
+    # Equity value with partial net-debt adjustment when capital-structure
+    # data is available. ``long_term_debt`` only — see compute_dcf docstring.
+    if cash is not None and long_term_debt is not None:
+        equity_value = enterprise_value + cash - long_term_debt
     else:
         equity_value = enterprise_value  # legacy: no net debt adj
 
@@ -221,7 +249,12 @@ def _run_dcf(
     cash = financials.cash_and_equivalents[-1].value if financials.cash_and_equivalents else None
 
     profile = market_profile or {}
-    beta = profile.get("beta") or 1.2  # fallback to legacy default
+    # Fallback only when beta is genuinely missing — a real beta of exactly
+    # 0.0 (rare but possible for cash-equivalent ETFs / hedged instruments)
+    # should not silently get rewritten to 1.2.
+    beta = profile.get("beta")
+    if beta is None:
+        beta = 1.2
     market_cap = profile.get("market_cap")
 
     discount_rate = _estimate_wacc(
@@ -250,7 +283,7 @@ def _run_dcf(
         discount_rate=discount_rate,
         shares_outstanding=shares,
         cash=cash,
-        total_debt=debt,
+        long_term_debt=debt,
     )
 
     if dcf_result["intrinsic_value_per_share"]:

--- a/backend/backend/agents/nodes/event_impact.py
+++ b/backend/backend/agents/nodes/event_impact.py
@@ -292,8 +292,18 @@ async def _run_event_impact(
     shares = None
     if financials.diluted_shares:
         shares = financials.diluted_shares[-1].value
+    cash = (
+        financials.cash_and_equivalents[-1].value
+        if financials.cash_and_equivalents
+        else None
+    )
+    debt = (
+        financials.long_term_debt[-1].value
+        if financials.long_term_debt
+        else None
+    )
 
-    recalculated_dcf = recalculate_dcf(adjusted_assumptions, shares)
+    recalculated_dcf = recalculate_dcf(adjusted_assumptions, shares, cash=cash, total_debt=debt)
 
     reasoning.append(f"Impact analysis summary: {analysis_result['summary']}")
     reasoning.append(f"Confidence: {analysis_result['confidence']:.0%}")

--- a/backend/backend/agents/nodes/event_impact.py
+++ b/backend/backend/agents/nodes/event_impact.py
@@ -303,7 +303,9 @@ async def _run_event_impact(
         else None
     )
 
-    recalculated_dcf = recalculate_dcf(adjusted_assumptions, shares, cash=cash, total_debt=debt)
+    recalculated_dcf = recalculate_dcf(
+        adjusted_assumptions, shares, cash=cash, long_term_debt=debt,
+    )
 
     reasoning.append(f"Impact analysis summary: {analysis_result['summary']}")
     reasoning.append(f"Confidence: {analysis_result['confidence']:.0%}")

--- a/backend/backend/agents/nodes/event_impact_math.py
+++ b/backend/backend/agents/nodes/event_impact_math.py
@@ -180,10 +180,13 @@ def apply_all_adjustments(
 def recalculate_dcf(
     adjusted_assumptions: dict[str, float],
     shares_outstanding: float | None,
+    cash: float | None = None,
+    total_debt: float | None = None,
 ) -> dict[str, Any]:
     """Run DCF model with adjusted assumptions.
 
     Converts percentage values to decimals before passing to compute_dcf.
+    Forwards ``cash`` and ``total_debt`` for net debt adjustment.
     """
     growth_rate = adjusted_assumptions.get("growth_rate", 10.0) / 100
     terminal_growth = adjusted_assumptions.get("terminal_growth_rate", 3.0) / 100
@@ -196,6 +199,8 @@ def recalculate_dcf(
         terminal_growth_rate=terminal_growth,
         discount_rate=discount_rate,
         shares_outstanding=shares_outstanding,
+        cash=cash,
+        total_debt=total_debt,
     )
 
 

--- a/backend/backend/agents/nodes/event_impact_math.py
+++ b/backend/backend/agents/nodes/event_impact_math.py
@@ -181,12 +181,13 @@ def recalculate_dcf(
     adjusted_assumptions: dict[str, float],
     shares_outstanding: float | None,
     cash: float | None = None,
-    total_debt: float | None = None,
+    long_term_debt: float | None = None,
 ) -> dict[str, Any]:
     """Run DCF model with adjusted assumptions.
 
     Converts percentage values to decimals before passing to compute_dcf.
-    Forwards ``cash`` and ``total_debt`` for net debt adjustment.
+    Forwards ``cash`` and ``long_term_debt`` for the partial net-debt
+    adjustment (see ``compute_dcf`` for the caveat about long-term-only debt).
     """
     growth_rate = adjusted_assumptions.get("growth_rate", 10.0) / 100
     terminal_growth = adjusted_assumptions.get("terminal_growth_rate", 3.0) / 100
@@ -200,7 +201,7 @@ def recalculate_dcf(
         discount_rate=discount_rate,
         shares_outstanding=shares_outstanding,
         cash=cash,
-        total_debt=total_debt,
+        long_term_debt=long_term_debt,
     )
 
 

--- a/backend/backend/agents/value_analyst.py
+++ b/backend/backend/agents/value_analyst.py
@@ -18,6 +18,7 @@ from backend.models.events import (
     ErrorEvent,
     StepCompleteEvent,
 )
+from backend.services.market_data import market_data_client
 from backend.services.sec_agent import sec_data_service
 from backend.services.ticker_resolver import TickerNotFoundError
 
@@ -75,6 +76,13 @@ async def fetch_sec_data_node(
             "fetch_errors": [str(e)],
             "reasoning_steps": [f"ERROR: SEC fetch failed - {e}"],
         }
+
+    # Fetch market profile (price/beta/market_cap) — best-effort, no hard fail.
+    # Used by DCF for live beta and negative-equity fallback.
+    try:
+        market_profile = await market_data_client.get_company_profile(ticker)
+    except Exception:
+        market_profile = {}
 
     writer(AgentThinkingEvent(
         node="fetch_sec_data",
@@ -161,6 +169,7 @@ async def fetch_sec_data_node(
 
     return {
         "financials": financials,
+        "market_profile": market_profile or None,
         "fetch_errors": [],
         "reasoning_steps": [
             f"Fetched SEC data for {financials.entity_name}",

--- a/backend/backend/api/routes.py
+++ b/backend/backend/api/routes.py
@@ -166,6 +166,8 @@ async def recalculate_dcf(
 
     latest_fcf = financials.free_cash_flow[-1].value
     shares = financials.diluted_shares[-1].value if financials.diluted_shares else None
+    cash = financials.cash_and_equivalents[-1].value if financials.cash_and_equivalents else None
+    debt = financials.long_term_debt[-1].value if financials.long_term_debt else None
 
     result = compute_dcf(
         latest_fcf=latest_fcf,
@@ -173,6 +175,8 @@ async def recalculate_dcf(
         terminal_growth_rate=payload.terminal_growth_rate / 100,
         discount_rate=payload.discount_rate / 100,
         shares_outstanding=shares,
+        cash=cash,
+        total_debt=debt,
     )
 
     # Include historical + projected FCF for chart update

--- a/backend/backend/api/routes.py
+++ b/backend/backend/api/routes.py
@@ -176,7 +176,7 @@ async def recalculate_dcf(
         discount_rate=payload.discount_rate / 100,
         shares_outstanding=shares,
         cash=cash,
-        total_debt=debt,
+        long_term_debt=debt,
     )
 
     # Include historical + projected FCF for chart update

--- a/backend/backend/models/agent_state.py
+++ b/backend/backend/models/agent_state.py
@@ -16,6 +16,8 @@ class AnalysisState(TypedDict):
     # SEC data
     financials: CompanyFinancials | None
     fetch_errors: list[str]
+    # Market profile (FMP): price, beta, market_cap, sector, industry
+    market_profile: dict[str, Any] | None
     # Financial health
     health_metrics: dict[str, Any] | None
     health_assessment: str | None

--- a/backend/backend/services/market_data.py
+++ b/backend/backend/services/market_data.py
@@ -53,10 +53,11 @@ class MarketDataClient:
         return None
 
     async def get_company_profile(self, ticker: str) -> dict[str, Any]:
-        """Fetch GICS sector/industry, TTM dividend, and price. Returns {} on failure.
+        """Fetch GICS sector/industry, TTM dividend, price, beta, and market cap.
 
-        Also returns ``price`` — the profile endpoint includes it and works on
-        FMP free-tier symbols that ``/stable/quote`` rejects as premium-only.
+        Returns {} on failure. Also returns ``price`` — the profile endpoint
+        includes it and works on FMP free-tier symbols that ``/stable/quote``
+        rejects as premium-only.
         """
         if not settings.fmp_api_key:
             return {}
@@ -71,11 +72,15 @@ class MarketDataClient:
                 item = data[0]
                 last_div = item.get("lastDividend")
                 price = item.get("price")
+                beta = item.get("beta")
+                mkt_cap = item.get("mktCap") or item.get("marketCap")
                 return {
                     "sector": item.get("sector") or None,
                     "industry": item.get("industry") or None,
                     "last_dividend": float(last_div) if last_div else None,
                     "price": float(price) if price else None,
+                    "beta": float(beta) if beta is not None else None,
+                    "market_cap": float(mkt_cap) if mkt_cap is not None else None,
                 }
         except httpx.HTTPStatusError as e:
             logger.warning("FMP get_company_profile(%s) HTTP %s", ticker, e.response.status_code)

--- a/backend/tests/agents/nodes/test_dcf_model.py
+++ b/backend/tests/agents/nodes/test_dcf_model.py
@@ -1,0 +1,164 @@
+"""Unit tests for dcf_model pure computation functions.
+
+Covers the four branches added/changed in the real-beta + net-debt PR:
+
+1. ``compute_dcf`` legacy mode (no ``cash``/``long_term_debt``) vs. partial
+   net-debt adjustment mode.
+2. ``_estimate_wacc`` market-cap fallback when book equity ≤ 0.
+3. ``_estimate_wacc`` 4 % WACC floor for very-low-beta names.
+4. (beta-fallback semantics — exercised via ``compute_dcf`` callers, see
+   ``test_beta_fallback_only_on_none`` in the dcf_node integration suite if
+   added later. The pure ``_estimate_wacc`` already takes ``beta`` as a
+   required argument so the fallback lives one layer up in ``_run_dcf``;
+   here we just sanity-check that ``beta=0.0`` does not blow up the WACC
+   computation when explicitly passed.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.agents.nodes.dcf_model import _estimate_wacc, compute_dcf
+
+
+# ---------------------------------------------------------------------------
+# compute_dcf — net-debt adjustment branch
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDcfNetDebtAdjustment:
+    """Equity value should reflect (EV + cash − long_term_debt) when both
+    capital-structure inputs are supplied; otherwise legacy EV-only path."""
+
+    BASE_KWARGS = {
+        "latest_fcf": 1_000_000.0,
+        "growth_rate": 0.10,
+        "terminal_growth_rate": 0.03,
+        "discount_rate": 0.10,
+        "shares_outstanding": 1_000_000.0,
+    }
+
+    def test_legacy_mode_equity_equals_enterprise_value(self) -> None:
+        """When cash/debt are omitted, equity_value == enterprise_value."""
+        result = compute_dcf(**self.BASE_KWARGS)
+        assert result["equity_value"] == result["enterprise_value"]
+
+    def test_only_cash_provided_falls_back_to_legacy(self) -> None:
+        """Net-debt adjustment requires BOTH cash and long_term_debt."""
+        result = compute_dcf(**self.BASE_KWARGS, cash=500_000.0)
+        assert result["equity_value"] == result["enterprise_value"]
+
+    def test_only_debt_provided_falls_back_to_legacy(self) -> None:
+        result = compute_dcf(**self.BASE_KWARGS, long_term_debt=500_000.0)
+        assert result["equity_value"] == result["enterprise_value"]
+
+    def test_both_provided_applies_adjustment(self) -> None:
+        """equity = EV + cash − long_term_debt (long-term debt only)."""
+        cash = 800_000.0
+        debt = 300_000.0
+        result = compute_dcf(**self.BASE_KWARGS, cash=cash, long_term_debt=debt)
+
+        ev = result["enterprise_value"]
+        expected_equity = round(ev + cash - debt, 2)
+        assert result["equity_value"] == expected_equity
+
+    def test_per_share_uses_adjusted_equity(self) -> None:
+        cash = 800_000.0
+        debt = 300_000.0
+        result = compute_dcf(**self.BASE_KWARGS, cash=cash, long_term_debt=debt)
+
+        expected_per_share = round(
+            result["equity_value"] / self.BASE_KWARGS["shares_outstanding"], 2
+        )
+        assert result["intrinsic_value_per_share"] == expected_per_share
+
+
+# ---------------------------------------------------------------------------
+# _estimate_wacc — market-cap fallback for non-positive book equity
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateWaccMarketCapFallback:
+    """Heavy-buyback names (MCD-style) carry negative retained earnings →
+    book equity ≤ 0. Without the fallback, the debt + equity branch is
+    skipped and we silently lose all capital-structure information. The
+    fallback substitutes market cap so the weighted-average still works."""
+
+    def test_negative_equity_with_market_cap_uses_market_cap(self) -> None:
+        wacc = _estimate_wacc(
+            debt=1_000.0,
+            equity=-500.0,           # buyback company, negative book equity
+            interest_expense=50.0,    # ~5% cost of debt
+            market_cap=10_000.0,      # large positive market cap
+            beta=1.0,
+        )
+        # Hand-computed expectation: cost_of_equity = 0.045 + 1.0*0.055 = 0.10
+        # cost_of_debt = 50/1000 = 0.05; after-tax = 0.05*(1-0.21) = 0.0395
+        # weights: equity = 10000/11000 ≈ 0.909, debt = 1000/11000 ≈ 0.091
+        # wacc ≈ 0.909*0.10 + 0.091*0.0395 ≈ 0.0945
+        assert wacc == pytest.approx(0.0945, abs=1e-3)
+
+    def test_negative_equity_without_market_cap_returns_cost_of_equity(self) -> None:
+        """No market cap → can't form WACC weights → fall back to cost of
+        equity (still floored at 4 %)."""
+        wacc = _estimate_wacc(
+            debt=1_000.0,
+            equity=-500.0,
+            interest_expense=50.0,
+            market_cap=None,
+            beta=1.0,
+        )
+        # Falls through to the cost_of_equity return
+        assert wacc == pytest.approx(0.10, abs=1e-3)
+
+    def test_positive_equity_does_not_use_market_cap(self) -> None:
+        """When book equity is positive, market cap is irrelevant."""
+        wacc_with_mcap = _estimate_wacc(
+            debt=1_000.0, equity=5_000.0, interest_expense=50.0,
+            market_cap=999_999.0, beta=1.0,
+        )
+        wacc_without_mcap = _estimate_wacc(
+            debt=1_000.0, equity=5_000.0, interest_expense=50.0,
+            market_cap=None, beta=1.0,
+        )
+        assert wacc_with_mcap == pytest.approx(wacc_without_mcap)
+
+
+# ---------------------------------------------------------------------------
+# _estimate_wacc — 4 % floor
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateWaccFloor:
+    """Defensive low-beta names (utilities, consumer staples) can produce
+    a WACC below 4 %, which dramatically over-values them. We floor at 4 %
+    as a guardrail; this test pins the threshold."""
+
+    def test_low_beta_clamped_to_floor(self) -> None:
+        wacc = _estimate_wacc(
+            debt=None, equity=None, interest_expense=None, beta=0.1,
+        )
+        # Raw cost of equity at beta=0.1: 0.045 + 0.1*0.055 = 0.0505
+        # No debt branch → returns max(0.0505, 0.04) = 0.0505 (above floor)
+        assert wacc == pytest.approx(0.0505, abs=1e-4)
+
+    def test_zero_beta_clamped_to_floor(self) -> None:
+        """beta=0 → cost_of_equity = 0.045 → floor kicks in at 4 %."""
+        wacc = _estimate_wacc(
+            debt=None, equity=None, interest_expense=None, beta=0.0,
+        )
+        # cost_of_equity = 0.045 which is above 0.04 → returned as-is
+        assert wacc == pytest.approx(0.045, abs=1e-4)
+
+    def test_full_branch_with_low_costs_floors_at_4pct(self) -> None:
+        """Explicit construction of a sub-4% WACC scenario: tiny beta + tiny
+        cost of debt + heavy debt weighting. Verifies the floor in the
+        full WACC branch (not just the cost-of-equity fallback)."""
+        wacc = _estimate_wacc(
+            debt=10_000.0,        # 91% debt weight
+            equity=1_000.0,
+            interest_expense=10.0,  # 0.1% cost of debt
+            beta=0.0,
+        )
+        # Without floor: ~0.91 * 0.0008 + 0.09 * 0.045 ≈ 0.0048 → clamps to 0.04
+        assert wacc == pytest.approx(0.04, abs=1e-6)

--- a/docs/decisions/002-two-stage-dcf.md
+++ b/docs/decisions/002-two-stage-dcf.md
@@ -54,7 +54,7 @@ DCF 估值模型有多种阶段划分方式。核心问题是如何建模公司�
 | terminal_growth | 3.0% | 固定假设 (近似GDP增长) |
 | WACC floor | 4% | 防止不合理低价折现（原 6%，对低 beta 防御股偏高） |
 
-**净债务调整**: 自 2026-05 起，`per_share = (EV + cash − debt) / shares`，而非早期版本的 `EV / shares`。后者忽略资本结构，对 KO 这类高净债公司高估、对 GOOG 这类高净现金公司低估。
+**部分净债务调整**: 自 2026-05 起，`per_share = (EV + cash − long_term_debt) / shares`，而非早期版本的 `EV / shares`。后者忽略资本结构，对 KO 这类高净债公司高估、对 GOOG 这类高净现金公司低估。当前仅扣**长期债务** — 短期借款 / 商业票据 / 长债当期 / 经营租赁负债待 SEC tag map 升级后补齐为完整 total debt。
 
 **负权益兜底**: 若 `stockholders_equity ≤ 0`（重度回购公司如 MCD），且 `market_profile.market_cap` 可用，则用市值替代权益权重计算 WACC，避免 E/V 为负数导致的数学异常。
 

--- a/docs/decisions/002-two-stage-dcf.md
+++ b/docs/decisions/002-two-stage-dcf.md
@@ -48,12 +48,17 @@ DCF 估值模型有多种阶段划分方式。核心问题是如何建模公司�
 |------|-----|------|
 | risk_free_rate | 4.5% | 硬编码 (美国10年期国债近似) |
 | equity_risk_premium | 5.5% | 硬编码 (历史平均) |
-| beta | 1.2 | 硬编码 (科技股近似) |
+| beta | 动态 / 1.2 | FMP `/stable/profile` 实时获取，缺失时回退 1.2 |
 | tax_rate | 21% | 硬编码 (美国联邦企业税) |
 | growth_cap | 30% | 防止不合理的极高增长 |
 | terminal_growth | 3.0% | 固定假设 (近似GDP增长) |
-| WACC floor | 6% | 防止不合理低价折现 |
+| WACC floor | 4% | 防止不合理低价折现（原 6%，对低 beta 防御股偏高） |
+
+**净债务调整**: 自 2026-05 起，`per_share = (EV + cash − debt) / shares`，而非早期版本的 `EV / shares`。后者忽略资本结构，对 KO 这类高净债公司高估、对 GOOG 这类高净现金公司低估。
+
+**负权益兜底**: 若 `stockholders_equity ≤ 0`（重度回购公司如 MCD），且 `market_profile.market_cap` 可用，则用市值替代权益权重计算 WACC，避免 E/V 为负数导致的数学异常。
 
 **未决问题**:
-- [ ] risk_free_rate 和 beta 应该从外部 API 动态获取，而不是硬编码
+- [x] beta 已通过 FMP 动态获取（risk_free_rate 仍硬编码）
 - [ ] 是否应支持用户选择衰减方式（线性 vs H-model）
+- [ ] 30% 增长率上限对 NVDA 类超高增长公司低估明显，需考虑动态上限

--- a/docs/nodes/03-dcf-model.md
+++ b/docs/nodes/03-dcf-model.md
@@ -15,20 +15,24 @@
 | 字段 | 类型 | 必需 | 说明 |
 |------|------|:----:|------|
 | `financials` | `CompanyFinancials` | ✅ | → [Node 1 输出](01-fetch-sec-data.md#companyfinancials-结构体) |
+| `market_profile` | `dict \| None` | ⬜ | FMP profile (price/beta/market_cap)，缺失 → beta 回退 1.2、负权益回退到 cost_of_equity |
 
 ### 子字段访问
 
-节点实际从 `financials` 访问以下子字段 (`_run_dcf`, line 146):
+节点实际从 `financials` 和 `market_profile` 访问以下子字段 (`_run_dcf`, line 146):
 
 | 访问路径 | 类型 | 必需 | 用途 |
 |----------|------|:----:|------|
 | `financials.entity_name` | `str` | ✅ | UI 显示 |
 | `financials.ticker` | `str` | ✅ | 日志 |
 | `financials.free_cash_flow` | `list[AnnualMetric]` | ✅ | FCF 时间序列，需 ≥ 1 年；CAGR 需 ≥ 3 年 |
-| `financials.long_term_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 (缺失 → 全权益模型) |
-| `financials.stockholders_equity[-1].value` | `float \| None` | ⬜ | WACC 权益部分 |
+| `financials.long_term_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 (缺失 → 全权益模型)，同时用作净债务调整中的 debt |
+| `financials.stockholders_equity[-1].value` | `float \| None` | ⬜ | WACC 权益部分 (≤ 0 → 回退 market_cap) |
 | `financials.interest_expense[-1].value` | `float \| None` | ⬜ | 计算债务成本 |
+| `financials.cash_and_equivalents[-1].value` | `float \| None` | ⬜ | 净债务调整: equity_value = EV + cash − debt |
 | `financials.diluted_shares[-1].value` | `float \| None` | ⬜ | 每股价值 (缺失 → `intrinsic_value_per_share = None`) |
+| `market_profile.beta` | `float \| None` | ⬜ | CAPM beta (缺失 → 回退 1.2) |
+| `market_profile.market_cap` | `float \| None` | ⬜ | 负权益时的权益权重兜底 |
 
 ### NVDA 示例 (输入子字段)
 
@@ -80,7 +84,8 @@
     "terminal_pv": float,                     # 终值现值 ($)
     "pv_fcf_sum": float,                      # FCF 现值之和 ($)
     "enterprise_value": float,                # 企业价值 = pv_fcf_sum + terminal_pv ($)
-    "intrinsic_value_per_share": float | None, # 内在价值 ($/股), shares 缺失时为 None
+    "equity_value": float,                    # 股权价值 = EV + cash − debt (净债务调整) ($)
+    "intrinsic_value_per_share": float | None, # 内在价值 = equity_value / shares ($/股)
     "assumptions": {
         "growth_rate": float,                 # 初始增长率 (%)
         "terminal_growth_rate": float,        # 永续增长率 (%), 固定 3.0
@@ -92,7 +97,8 @@
 ```
 
 > **增长率估算**: `3yr CAGR × 0.6 + 5yr CAGR × 0.4`，上限 30%，下限 2%。不足时回退 10%。
-> **WACC**: `risk_free(4.5%) + beta(1.2) × ERP(5.5%)` 基础 + 债务调整 (无债务数据时回退 cost_of_equity)，下限 6%。
+> **WACC**: `risk_free(4.5%) + beta × ERP(5.5%)` 基础 + 债务调整。Beta 优先取 `market_profile.beta` (FMP)，缺失时回退 1.2。负权益时用 market_cap 替代权益权重。下限 4%。
+> **股权价值**: `EV + cash − debt`（净债务调整）；`per_share = equity_value / shares`。
 
 ### NVDA 示例 (输出)
 
@@ -137,10 +143,12 @@
    └── 封顶: min(max(raw_growth, 2%), 30%)
 
 2. 估算 WACC:
-   ├── cost_of_equity = risk_free(4.5%) + beta(1.2) × ERP(5.5%) = 11.1%
+   ├── beta = market_profile.beta or 1.2  (优先 FMP 实时值)
+   ├── cost_of_equity = risk_free(4.5%) + beta × ERP(5.5%)
    ├── cost_of_debt = interest / debt (仅当债务数据完整时)
+   ├── 若 stockholders_equity ≤ 0 且有 market_cap → 用 market_cap 替代权益权重
    ├── WACC = (E/V)×Re + (D/V)×Rd×(1-T)
-   └── floor: max(WACC, 6%)
+   └── floor: max(WACC, 4%)
    └── 债务数据缺失 → 回退全权益模型
 
 3. 两阶段 DCF (compute_dcf):
@@ -148,15 +156,17 @@
    ├── Phase 2 (Y6-10): 线性衰减 growth → terminal(3%)
    ├── Terminal Value = Y10_FCF × (1+terminal) / (discount - terminal)
    ├── EV = Σ PV(FCF) + PV(TV)
-   └── Intrinsic/Share = EV / diluted_shares
+   ├── Equity Value = EV + cash − debt  (净债务调整)
+   └── Intrinsic/Share = Equity Value / diluted_shares
 ```
 
 ## 关键假设
 
 - **两阶段 DCF 而非三阶段** → [ADR 002](../decisions/002-two-stage-dcf.md)
 - **独立重算端点而非重跑全图** → [ADR 004](../decisions/004-separate-recalc-endpoint.md)
-- WACC 参数硬编码：risk_free=4.5%, ERP=5.5%, beta=1.2, tax=21%
-- 增长率上限 30%，WACC 下限 6%，永续增长率固定 3%
+- WACC 参数：risk_free=4.5%, ERP=5.5%, tax=21% 硬编码；beta 从 FMP 动态获取（缺失时回退 1.2）
+- 增长率上限 30%，WACC 下限 4%，永续增长率固定 3%
+- 每股内在价值含净债务调整：`(EV + cash − debt) / shares`
 
 ## LLM 使用
 
@@ -195,5 +205,6 @@
 
 ## 未决问题 / TODO
 
-- [ ] risk_free_rate, beta 应从外部 API 动态获取
+- [x] beta 已从 FMP 动态获取（risk_free_rate 仍硬编码）
 - [ ] 是否支持用户选择衰减方式（线性 vs H-model）
+- [ ] 30% 增长率上限对超高增长公司（NVDA 类）严重低估，需要动态上限

--- a/docs/nodes/03-dcf-model.md
+++ b/docs/nodes/03-dcf-model.md
@@ -26,10 +26,10 @@
 | `financials.entity_name` | `str` | ✅ | UI 显示 |
 | `financials.ticker` | `str` | ✅ | 日志 |
 | `financials.free_cash_flow` | `list[AnnualMetric]` | ✅ | FCF 时间序列，需 ≥ 1 年；CAGR 需 ≥ 3 年 |
-| `financials.long_term_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 (缺失 → 全权益模型)，同时用作净债务调整中的 debt |
+| `financials.long_term_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 (缺失 → 全权益模型)，同时用作部分净债务调整中扣减项（仅长期债务） |
 | `financials.stockholders_equity[-1].value` | `float \| None` | ⬜ | WACC 权益部分 (≤ 0 → 回退 market_cap) |
 | `financials.interest_expense[-1].value` | `float \| None` | ⬜ | 计算债务成本 |
-| `financials.cash_and_equivalents[-1].value` | `float \| None` | ⬜ | 净债务调整: equity_value = EV + cash − debt |
+| `financials.cash_and_equivalents[-1].value` | `float \| None` | ⬜ | 部分净债务调整: equity_value = EV + cash − long_term_debt |
 | `financials.diluted_shares[-1].value` | `float \| None` | ⬜ | 每股价值 (缺失 → `intrinsic_value_per_share = None`) |
 | `market_profile.beta` | `float \| None` | ⬜ | CAPM beta (缺失 → 回退 1.2) |
 | `market_profile.market_cap` | `float \| None` | ⬜ | 负权益时的权益权重兜底 |
@@ -98,7 +98,7 @@
 
 > **增长率估算**: `3yr CAGR × 0.6 + 5yr CAGR × 0.4`，上限 30%，下限 2%。不足时回退 10%。
 > **WACC**: `risk_free(4.5%) + beta × ERP(5.5%)` 基础 + 债务调整。Beta 优先取 `market_profile.beta` (FMP)，缺失时回退 1.2。负权益时用 market_cap 替代权益权重。下限 4%。
-> **股权价值**: `EV + cash − debt`（净债务调整）；`per_share = equity_value / shares`。
+> **股权价值**: `EV + cash − long_term_debt`（**部分** 净债务调整：当前 SEC tag map 仅暴露长期债务，未聚合短期借款 / 商业票据 / 长债当期 / 经营租赁负债 — 后续 PR 补全）；`per_share = equity_value / shares`。
 
 ### NVDA 示例 (输出)
 
@@ -156,7 +156,7 @@
    ├── Phase 2 (Y6-10): 线性衰减 growth → terminal(3%)
    ├── Terminal Value = Y10_FCF × (1+terminal) / (discount - terminal)
    ├── EV = Σ PV(FCF) + PV(TV)
-   ├── Equity Value = EV + cash − debt  (净债务调整)
+   ├── Equity Value = EV + cash − long_term_debt  (部分净债务调整, 仅长期债务)
    └── Intrinsic/Share = Equity Value / diluted_shares
 ```
 
@@ -166,7 +166,7 @@
 - **独立重算端点而非重跑全图** → [ADR 004](../decisions/004-separate-recalc-endpoint.md)
 - WACC 参数：risk_free=4.5%, ERP=5.5%, tax=21% 硬编码；beta 从 FMP 动态获取（缺失时回退 1.2）
 - 增长率上限 30%，WACC 下限 4%，永续增长率固定 3%
-- 每股内在价值含净债务调整：`(EV + cash − debt) / shares`
+- 每股内在价值含**部分**净债务调整：`(EV + cash − long_term_debt) / shares`（仅扣长期债务；短期借款 / 商业票据 / 长债当期 / 租赁负债待 SEC tag map 升级后补全）
 
 ## LLM 使用
 


### PR DESCRIPTION
## Summary

- **Real beta** from FMP profile API replaces hardcoded `beta=1.2` (silent fallback to 1.2 if FMP unavailable)
- **Net debt adjustment**: per-share intrinsic value = `(EV + cash − debt) / shares` instead of just `EV / shares`
- **WACC floor 6% → 4%** + market-cap fallback when book equity ≤ 0 (handles MCD-style buyback companies)

Backwards compatible — `compute_dcf` accepts `cash` and `total_debt` as optional kwargs; behavior is identical to before when omitted.

## Why

The current DCF treats every company like an "average tech stock" (β=1.2, no net debt adjustment, 6% WACC floor). This badly mis-prices the actual common case (mature dividend payers with debt), and breaks entirely on heavy-buyback companies whose book equity went negative.

I tested across KO / MCD / NVDA / TSLA — KO and MCD are dramatically more accurate after these changes (closer to live market). NVDA and TSLA are still wrong, but for a different reason (30% growth-rate cap doesn't capture hyper-growth) — separate fix.

## Where to focus review

1. **State plumbing** ([backend/agents/value_analyst.py](https://github.com/hymanqiu/alphaquant/blob/feature/dcf-real-beta-and-net-debt/backend/backend/agents/value_analyst.py)) — am I wiring \`market_profile\` through state correctly? It's an optional field; if FMP fails, the dict is empty and DCF falls back gracefully.
2. **WACC negative-equity branch** ([backend/agents/nodes/dcf_model.py:_estimate_wacc](https://github.com/hymanqiu/alphaquant/blob/feature/dcf-real-beta-and-net-debt/backend/backend/agents/nodes/dcf_model.py)) — when book equity ≤ 0 and we have market cap, swap in market cap for the equity weight. Sanity check this logic.
3. **FMP profile parsing** ([backend/services/market_data.py](https://github.com/hymanqiu/alphaquant/blob/feature/dcf-real-beta-and-net-debt/backend/backend/services/market_data.py)) — I assumed FMP returns \`beta\` and \`mktCap\` based on docs; **not yet verified live**. If you have an FMP key handy, check whether these fields actually come back.
4. **\`compute_dcf\` signature change** — adding optional kwargs. Any other callers I missed? (I found 3: \`_run_dcf\`, \`recalculate_dcf\` in event_impact_math, \`/api/recalculate-dcf\` route — all updated.)

## Test plan

- [x] 133/133 existing tests pass
- [x] Smoke test 5 scenarios (legacy mode, KO net debt, beta override, negative equity fallback, WACC floor) — all match expected values
- [ ] **NOT YET DONE — end-to-end live test**: run \`make backend\`, hit \`/api/analyze/KO\`, confirm intrinsic value lands near $70 (textbook DCF) instead of $32 (old behavior). If a reviewer can do this, that closes the loop.

## Out of scope (future PRs)

- Lifting the 30% growth cap dynamically (would help NVDA-class hyper-growth)
- Detecting "DCF inappropriate" companies (TSLA-class option-value-driven names) and skipping
- Making \`market_profile\` a proper Pydantic model instead of \`dict[str, Any]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)