### PR TITLE
fix(sec): merge XBRL fallback tags by year to preserve historical series

### DIFF
--- a/backend/backend/services/sec_agent.py
+++ b/backend/backend/services/sec_agent.py
@@ -135,27 +135,20 @@ def _extract_annual_metrics(
     tag_candidates: list[str],
     unit: str = "USD",
 ) -> list[AnnualMetric]:
-    """Try all XBRL tag candidates. Return the one with the most recent data."""
-    best: list[AnnualMetric] = []
-    best_latest_year = -1
+    """Merge candidate XBRL tags by calendar year.
 
+    Earlier tags in tag_candidates win for any given year (TAG_MAP encodes
+    preference — modern lease-inclusive tags are listed first). Later legacy
+    tags fill in years the preferred tag does not cover, preserving deep
+    history for relative-valuation use.
+    """
+    merged: dict[int, AnnualMetric] = {}
     for tag in tag_candidates:
         if tag not in facts:
             continue
-
-        result = _extract_for_tag(facts[tag], unit)
-        if not result:
-            continue
-
-        latest_year = result[-1].calendar_year
-        # Prefer tag with most recent data; break ties by count
-        if latest_year > best_latest_year or (
-            latest_year == best_latest_year and len(result) > len(best)
-        ):
-            best = result
-            best_latest_year = latest_year
-
-    return best
+        for metric in _extract_for_tag(facts[tag], unit):
+            merged.setdefault(metric.calendar_year, metric)
+    return sorted(merged.values(), key=lambda m: m.calendar_year)
 
 
 def _compute_free_cash_flow(

--- a/backend/tests/services/test_sec_agent.py
+++ b/backend/tests/services/test_sec_agent.py
@@ -1,0 +1,102 @@
+"""Unit tests for sec_agent XBRL extraction."""
+
+from __future__ import annotations
+
+from backend.models.sec import SECFact, SECFactEntry, SECFactUnits
+from backend.services.sec_agent import _extract_annual_metrics
+
+
+def _entry(year: int, val: float, *, filed: str | None = None) -> SECFactEntry:
+    return SECFactEntry(
+        end=f"{year}-12-31",
+        val=val,
+        accn=f"acc-{year}",
+        fy=year,
+        fp="FY",
+        form="10-K",
+        filed=filed or f"{year + 1}-02-01",
+        frame=f"CY{year}",
+    )
+
+
+def _fact(*entries: SECFactEntry) -> SECFact:
+    return SECFact(units=SECFactUnits(USD=list(entries)))
+
+
+def test_merge_fresh_tag_with_legacy_history() -> None:
+    """Preferred tag with only 2024 + legacy with 2020–2022 → merged contains all years."""
+    facts = {
+        "LongTermDebtAndCapitalLeaseObligations": _fact(_entry(2024, 42_400.0)),
+        "LongTermDebt": _fact(
+            _entry(2020, 30_000.0),
+            _entry(2021, 32_000.0),
+            _entry(2022, 35_000.0),
+        ),
+    }
+    result = _extract_annual_metrics(
+        facts,
+        ["LongTermDebtAndCapitalLeaseObligations", "LongTermDebt", "LongTermDebtNoncurrent"],
+    )
+    assert [m.calendar_year for m in result] == [2020, 2021, 2022, 2024]
+    assert result[-1].value == 42_400.0  # ASC 842 value preserved
+    assert result[0].value == 30_000.0  # legacy 2020 preserved
+
+
+def test_same_year_in_two_tags_earlier_candidate_wins() -> None:
+    """If preferred and legacy share a year, the earlier-listed tag wins."""
+    facts = {
+        "LongTermDebtAndCapitalLeaseObligations": _fact(_entry(2022, 99.0)),
+        "LongTermDebt": _fact(_entry(2022, 11.0), _entry(2021, 10.0)),
+    }
+    result = _extract_annual_metrics(
+        facts,
+        ["LongTermDebtAndCapitalLeaseObligations", "LongTermDebt"],
+    )
+    by_year = {m.calendar_year: m.value for m in result}
+    assert by_year == {2021: 10.0, 2022: 99.0}
+
+
+def test_only_legacy_tag_present_no_regression() -> None:
+    """Tickers whose legacy series is already complete are unchanged."""
+    legacy = _fact(_entry(2020, 1.0), _entry(2021, 2.0), _entry(2022, 3.0))
+    facts = {"LongTermDebt": legacy}
+    result = _extract_annual_metrics(
+        facts, ["LongTermDebtAndCapitalLeaseObligations", "LongTermDebt"]
+    )
+    assert [(m.calendar_year, m.value) for m in result] == [(2020, 1.0), (2021, 2.0), (2022, 3.0)]
+
+
+def test_no_matching_tags_returns_empty() -> None:
+    assert _extract_annual_metrics({}, ["LongTermDebt"]) == []
+    assert _extract_annual_metrics({"Other": _fact(_entry(2024, 1.0))}, ["LongTermDebt"]) == []
+
+
+def test_quarterly_and_non_fy_entries_filtered() -> None:
+    """Merge must not bypass _extract_for_tag's filters."""
+    quarterly = SECFactEntry(
+        end="2024-03-31",
+        val=5.0,
+        accn="acc-q",
+        fy=2024,
+        fp="Q1",
+        form="10-Q",
+        filed="2024-05-01",
+        frame="CY2024Q1",
+    )
+    no_frame = SECFactEntry(
+        end="2024-12-31",
+        val=7.0,
+        accn="acc-nf",
+        fy=2024,
+        fp="FY",
+        form="10-K",
+        filed="2025-02-01",
+        frame=None,
+    )
+    facts = {
+        "LongTermDebt": SECFact(
+            units=SECFactUnits(USD=[quarterly, no_frame, _entry(2023, 100.0)])
+        )
+    }
+    result = _extract_annual_metrics(facts, ["LongTermDebt"])
+    assert [(m.calendar_year, m.value) for m in result] == [(2023, 100.0)]


### PR DESCRIPTION
## Summary

- Rewrite `_extract_annual_metrics()` to merge candidate XBRL tags by calendar year (earlier tag in `TAG_MAP` wins per year via `dict.setdefault`) instead of picking one full series.
- Add 5 unit tests in new `backend/tests/services/test_sec_agent.py` (first dedicated tests for this module).

## Why

PR #10 added the ASC 842 `LongTermDebtAndCapitalLeaseObligations` tag to the front of the `long_term_debt` fallback chain. That fixed latest-year DCF for filers like KO but exposed an extractor edge case: when the preferred tag has only recent data (KO's new tag has only 2024), the old "pick one full series" logic discards the legacy tag's deep history. Historical relative valuation in [`relative_valuation_math.py:148`](backend/backend/agents/nodes/relative_valuation_math.py#L148) then silently substitutes `0` for missing years, understating historical EV.

The merge is generic — it applies to every metric in `TAG_MAP`, not just `long_term_debt`.

## Behavior

| Scenario | Old | New |
|---|---|---|
| Preferred tag has only 2024; legacy has 2013–2022 | `[2024]` only | `[2013…2022, 2024]` |
| Preferred and legacy share same year, different values | Picks preferred series whole | Preferred value wins per shared year; legacy fills gaps |
| Legacy series already complete; preferred tag absent | unchanged | unchanged |
| Only preferred tag exists | unchanged | unchanged |

## Live verification

| Ticker | `long_term_debt` years (after) | Latest 2024 value |
|---|---|---|
| KO | `[2008, 2009, 2010, 2012, 2013, 2015, 2016, 2018, 2019, 2020, 2021, 2022, 2024]` | \$42.4B (lease-inclusive) |
| AAPL | `[2012…2024]` (12 yrs) | \$96.66B |
| MSFT | `[2009…2024]` (13 yrs) | \$44.94B |

KO before this PR returned only `[2024]` for `long_term_debt`.

## Test plan

- [x] 5 new unit tests in `tests/services/test_sec_agent.py` (merge, same-year tie-break, no-regression with only legacy tag, empty inputs, quarterly/non-FY filter pass-through)
- [x] 149/149 backend tests pass (144 pre-existing + 5 new)
- [x] Live verified KO: 2024 lease-inclusive value present, deep history preserved
- [x] Live verified AAPL & MSFT: no regression on tickers with already-complete legacy series
- [ ] Reviewer can spot-check additional tickers if desired

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)