### PR TITLE
feat(dcf): aggregate total_debt for full net-debt adjustment

### DIFF
--- a/backend/backend/agents/nodes/dcf_model.py
+++ b/backend/backend/agents/nodes/dcf_model.py
@@ -87,22 +87,18 @@ def compute_dcf(
     projection_years: int = 10,
     shares_outstanding: float | None = None,
     cash: float | None = None,
-    long_term_debt: float | None = None,
+    total_debt: float | None = None,
 ) -> dict[str, Any]:
     """Run the 2-stage DCF model.
 
-    If both ``cash`` and ``long_term_debt`` are provided, applies a partial
-    net-debt adjustment: per-share = (EV + cash − long_term_debt) / shares.
-    Otherwise falls back to EV / shares (legacy behavior, ignores capital
-    structure).
+    If both ``cash`` and ``total_debt`` are provided, applies a net-debt
+    adjustment: per-share = (EV + cash − total_debt) / shares. Otherwise
+    falls back to EV / shares (legacy behavior, ignores capital structure).
 
-    NOTE — this is **long-term** debt only, not full total debt. The current
-    SEC tag map exposes ``long_term_debt`` but does not yet aggregate
-    short-term borrowings, commercial paper, current portion of long-term
-    debt, or operating lease liabilities. For companies that lean heavily on
-    those, equity value is currently slightly overstated. A follow-up will
-    extend the SEC ingestion to a true total-debt field; until then the
-    parameter name reflects what we actually subtract.
+    ``total_debt`` is the aggregate from ``CompanyFinancials.total_debt`` —
+    long-term debt + short-term borrowings + current portion of LTD, summed
+    component-wise by calendar year. Operating-lease liabilities are
+    intentionally excluded; see ADR 002 for rationale.
     """
     projected_fcf: list[dict[str, Any]] = []
     high_growth_years = projection_years // 2
@@ -140,10 +136,11 @@ def compute_dcf(
     pv_fcf_sum = sum(p["present_value"] for p in projected_fcf)
     enterprise_value = pv_fcf_sum + terminal_pv
 
-    # Equity value with partial net-debt adjustment when capital-structure
-    # data is available. ``long_term_debt`` only — see compute_dcf docstring.
-    if cash is not None and long_term_debt is not None:
-        equity_value = enterprise_value + cash - long_term_debt
+    # Equity value with net-debt adjustment when capital-structure data is
+    # available. ``total_debt`` covers long-term + short-term + current
+    # portion of LTD; see compute_dcf docstring.
+    if cash is not None and total_debt is not None:
+        equity_value = enterprise_value + cash - total_debt
     else:
         equity_value = enterprise_value  # legacy: no net debt adj
 
@@ -242,8 +239,11 @@ def _run_dcf(
         content=f"FCF growth rate: {growth_rate * 100:.1f}% (3yr CAGR: {growth_3yr * 100:.1f}% weighted with 5yr)" if growth_3yr else f"FCF growth rate: {growth_rate * 100:.1f}%",
     ).model_dump())
 
-    # Estimate WACC — uses live beta from market_profile when available
-    debt = financials.long_term_debt[-1].value if financials.long_term_debt else None
+    # Estimate WACC — uses live beta from market_profile when available.
+    # ``debt`` reads from total_debt (LT + ST + current portion of LTD) so
+    # WACC's debt weighting and the implied cost-of-debt denominator match
+    # the same scope as the net-debt subtraction in equity-value math.
+    debt = financials.total_debt[-1].value if financials.total_debt else None
     equity = financials.stockholders_equity[-1].value if financials.stockholders_equity else None
     interest = financials.interest_expense[-1].value if financials.interest_expense else None
     cash = financials.cash_and_equivalents[-1].value if financials.cash_and_equivalents else None
@@ -283,7 +283,7 @@ def _run_dcf(
         discount_rate=discount_rate,
         shares_outstanding=shares,
         cash=cash,
-        long_term_debt=debt,
+        total_debt=debt,
     )
 
     if dcf_result["intrinsic_value_per_share"]:

--- a/backend/backend/agents/nodes/event_impact.py
+++ b/backend/backend/agents/nodes/event_impact.py
@@ -298,13 +298,13 @@ async def _run_event_impact(
         else None
     )
     debt = (
-        financials.long_term_debt[-1].value
-        if financials.long_term_debt
+        financials.total_debt[-1].value
+        if financials.total_debt
         else None
     )
 
     recalculated_dcf = recalculate_dcf(
-        adjusted_assumptions, shares, cash=cash, long_term_debt=debt,
+        adjusted_assumptions, shares, cash=cash, total_debt=debt,
     )
 
     reasoning.append(f"Impact analysis summary: {analysis_result['summary']}")

--- a/backend/backend/agents/nodes/event_impact_math.py
+++ b/backend/backend/agents/nodes/event_impact_math.py
@@ -181,13 +181,12 @@ def recalculate_dcf(
     adjusted_assumptions: dict[str, float],
     shares_outstanding: float | None,
     cash: float | None = None,
-    long_term_debt: float | None = None,
+    total_debt: float | None = None,
 ) -> dict[str, Any]:
     """Run DCF model with adjusted assumptions.
 
     Converts percentage values to decimals before passing to compute_dcf.
-    Forwards ``cash`` and ``long_term_debt`` for the partial net-debt
-    adjustment (see ``compute_dcf`` for the caveat about long-term-only debt).
+    Forwards ``cash`` and ``total_debt`` for the net-debt adjustment.
     """
     growth_rate = adjusted_assumptions.get("growth_rate", 10.0) / 100
     terminal_growth = adjusted_assumptions.get("terminal_growth_rate", 3.0) / 100
@@ -201,7 +200,7 @@ def recalculate_dcf(
         discount_rate=discount_rate,
         shares_outstanding=shares_outstanding,
         cash=cash,
-        long_term_debt=long_term_debt,
+        total_debt=total_debt,
     )
 
 

--- a/backend/backend/agents/nodes/logic_trace.py
+++ b/backend/backend/agents/nodes/logic_trace.py
@@ -87,7 +87,7 @@ def _run_logic_trace(state: AnalysisState, financials: Any, writer: StreamWriter
         ("Capital Expenditure", financials.capital_expenditure),
         ("Free Cash Flow", financials.free_cash_flow),
         ("Interest Expense", financials.interest_expense),
-        ("Long-Term Debt", financials.long_term_debt),
+        ("Total Debt", financials.total_debt),
         ("Cash & Equivalents", financials.cash_and_equivalents),
         ("Diluted EPS", financials.diluted_eps),
         ("Diluted Shares", financials.diluted_shares),

--- a/backend/backend/agents/nodes/relative_valuation_math.py
+++ b/backend/backend/agents/nodes/relative_valuation_math.py
@@ -74,9 +74,16 @@ def compute_current_multiples(
         return {"price_available": True, "multiples": {}}
 
     market_cap = current_price * shares
-    lt_debt = latest(financials.long_term_debt) or 0
+    # EV uses total_debt (LT + ST + current portion of LTD), matching the
+    # net-debt scope used by DCF. Falls back to long_term_debt when total_debt
+    # is empty so older/sparse filings still produce a defensible EV.
+    debt = (
+        latest(financials.total_debt)
+        or latest(financials.long_term_debt)
+        or 0
+    )
     cash = latest(financials.cash_and_equivalents) or 0
-    ev = market_cap + lt_debt - cash
+    ev = market_cap + debt - cash
 
     revenue = latest(financials.revenue)
     net_income = latest(financials.net_income)
@@ -124,7 +131,9 @@ def compute_historical_multiples(
     ni_by_year = by_year(financials.net_income)
     op_income_by_year = by_year(financials.operating_income)
     equity_by_year = by_year(financials.stockholders_equity)
-    debt_by_year = by_year(financials.long_term_debt)
+    # Same debt-scope choice as compute_current_multiples: prefer total_debt,
+    # fall back to long_term_debt if the aggregate is empty for that ticker.
+    debt_by_year = by_year(financials.total_debt or financials.long_term_debt)
     cash_by_year = by_year(financials.cash_and_equivalents)
     da_by_year = by_year(
         getattr(financials, "depreciation_and_amortization", []) or []

--- a/backend/backend/api/routes.py
+++ b/backend/backend/api/routes.py
@@ -174,7 +174,7 @@ async def recalculate_dcf(
     latest_fcf = financials.free_cash_flow[-1].value
     shares = financials.diluted_shares[-1].value if financials.diluted_shares else None
     cash = financials.cash_and_equivalents[-1].value if financials.cash_and_equivalents else None
-    debt = financials.long_term_debt[-1].value if financials.long_term_debt else None
+    debt = financials.total_debt[-1].value if financials.total_debt else None
 
     result = compute_dcf(
         latest_fcf=latest_fcf,
@@ -183,7 +183,7 @@ async def recalculate_dcf(
         discount_rate=payload.discount_rate / 100,
         shares_outstanding=shares,
         cash=cash,
-        long_term_debt=debt,
+        total_debt=debt,
     )
 
     # Include historical + projected FCF for chart update

--- a/backend/backend/models/financial.py
+++ b/backend/backend/models/financial.py
@@ -33,6 +33,17 @@ class CompanyFinancials(BaseModel):
     free_cash_flow: list[AnnualMetric] = []
     interest_expense: list[AnnualMetric] = []
     long_term_debt: list[AnnualMetric] = []
+    # Short-term borrowings (commercial paper, notes payable, etc.) reported
+    # under current liabilities. Distinct from ``long_term_debt_current``,
+    # which is the *current portion* of long-term debt (within 1y maturity).
+    short_term_debt: list[AnnualMetric] = []
+    long_term_debt_current: list[AnnualMetric] = []
+    # Aggregate: long_term_debt + short_term_debt + long_term_debt_current,
+    # summed component-wise by calendar year. Operating-lease liabilities are
+    # NOT included in v1 (analytical choice — see docs/decisions/002 for the
+    # rationale). Use this for any DCF / EV calculation rather than reading
+    # individual components, so debt coverage stays consistent across nodes.
+    total_debt: list[AnnualMetric] = []
     cash_and_equivalents: list[AnnualMetric] = []
     diluted_eps: list[AnnualMetric] = []
     diluted_shares: list[AnnualMetric] = []

--- a/backend/backend/services/sec_agent.py
+++ b/backend/backend/services/sec_agent.py
@@ -49,6 +49,21 @@ TAG_MAP: dict[str, list[str]] = {
         "LongTermDebt",
         "LongTermDebtNoncurrent",
     ],
+    "short_term_debt": [
+        # Short-term borrowings reported under current liabilities. Companies
+        # use a mix of these tags — commercial paper specifically when CP is
+        # the dominant funding mode, ShortTermBorrowings as a generic catch-all,
+        # NotesPayableCurrent for older filings.
+        "ShortTermBorrowings",
+        "CommercialPaper",
+        "NotesPayableCurrent",
+    ],
+    "long_term_debt_current": [
+        # Current portion of long-term debt — the slice maturing within 12mo
+        # carved out from total long-term debt. KO and MCD both report
+        # multi-billion values here, materially affecting net-debt math.
+        "LongTermDebtCurrent",
+    ],
     "cash_and_equivalents": [
         "CashAndCashEquivalentsAtCarryingValue",
         "CashCashEquivalentsAndShortTermInvestments",
@@ -151,6 +166,53 @@ def _extract_annual_metrics(
     return sorted(merged.values(), key=lambda m: m.calendar_year)
 
 
+def _compute_total_debt(
+    components: list[list[AnnualMetric]],
+) -> list[AnnualMetric]:
+    """Sum debt components by calendar year.
+
+    Each component (long-term debt, short-term debt, current portion of LTD)
+    is a series ``list[AnnualMetric]`` keyed by ``calendar_year``. We
+    aggregate per-year by summing whichever components have a value for
+    that year — missing components are skipped, NOT zero-filled, so
+    coverage gaps don't silently understate debt with phantom zeros.
+
+    Metadata (filing_date, accession, form) for the aggregate row is taken
+    from the most-recently-filed component for that year, which keeps
+    ``total_debt[-1]`` traceable to a real filing in audit trails.
+
+    Returns ``[]`` if no component has any data for any year — callers
+    should treat empty ``total_debt`` as "fall back to a debt-free DCF",
+    matching prior behavior when ``long_term_debt`` was empty.
+    """
+    if not any(components):
+        return []
+
+    by_year: dict[int, list[AnnualMetric]] = {}
+    for series in components:
+        for m in series:
+            by_year.setdefault(m.calendar_year, []).append(m)
+
+    result: list[AnnualMetric] = []
+    for cy in sorted(by_year):
+        rows = by_year[cy]
+        total = sum(m.value for m in rows)
+        # Most-recently-filed row provides the canonical metadata. Strings
+        # sort lexicographically which is correct for ISO filing dates.
+        anchor = max(rows, key=lambda m: m.filing_date)
+        result.append(
+            AnnualMetric(
+                calendar_year=cy,
+                value=total,
+                fiscal_year=anchor.fiscal_year,
+                filing_date=anchor.filing_date,
+                sec_accession=anchor.sec_accession,
+                form=anchor.form,
+            )
+        )
+    return result
+
+
 def _compute_free_cash_flow(
     ocf: list[AnnualMetric], capex: list[AnnualMetric]
 ) -> list[AnnualMetric]:
@@ -194,6 +256,16 @@ class SECDataService:
         data["free_cash_flow"] = _compute_free_cash_flow(
             data["operating_cash_flow"], data["capital_expenditure"]
         )
+
+        # Aggregate debt components into total_debt. Done after the per-tag
+        # extraction so each component still lives as its own field on
+        # CompanyFinancials (useful for audit / logic_trace), with total_debt
+        # as the canonical input for DCF / EV math.
+        data["total_debt"] = _compute_total_debt([
+            data["long_term_debt"],
+            data["short_term_debt"],
+            data["long_term_debt_current"],
+        ])
 
         return CompanyFinancials(
             cik=facts.cik,

--- a/backend/tests/agents/nodes/test_dcf_model.py
+++ b/backend/tests/agents/nodes/test_dcf_model.py
@@ -2,8 +2,8 @@
 
 Covers the four branches added/changed in the real-beta + net-debt PR:
 
-1. ``compute_dcf`` legacy mode (no ``cash``/``long_term_debt``) vs. partial
-   net-debt adjustment mode.
+1. ``compute_dcf`` legacy mode (no ``cash``/``total_debt``) vs. net-debt
+   adjustment mode.
 2. ``_estimate_wacc`` market-cap fallback when book equity ≤ 0.
 3. ``_estimate_wacc`` 4 % WACC floor for very-low-beta names.
 4. (beta-fallback semantics — exercised via ``compute_dcf`` callers, see
@@ -28,7 +28,7 @@ from backend.models.financial import AnnualMetric, CompanyFinancials
 
 
 class TestComputeDcfNetDebtAdjustment:
-    """Equity value should reflect (EV + cash − long_term_debt) when both
+    """Equity value should reflect (EV + cash − total_debt) when both
     capital-structure inputs are supplied; otherwise legacy EV-only path."""
 
     BASE_KWARGS = {
@@ -45,19 +45,19 @@ class TestComputeDcfNetDebtAdjustment:
         assert result["equity_value"] == result["enterprise_value"]
 
     def test_only_cash_provided_falls_back_to_legacy(self) -> None:
-        """Net-debt adjustment requires BOTH cash and long_term_debt."""
+        """Net-debt adjustment requires BOTH cash and total_debt."""
         result = compute_dcf(**self.BASE_KWARGS, cash=500_000.0)
         assert result["equity_value"] == result["enterprise_value"]
 
     def test_only_debt_provided_falls_back_to_legacy(self) -> None:
-        result = compute_dcf(**self.BASE_KWARGS, long_term_debt=500_000.0)
+        result = compute_dcf(**self.BASE_KWARGS, total_debt=500_000.0)
         assert result["equity_value"] == result["enterprise_value"]
 
     def test_both_provided_applies_adjustment(self) -> None:
-        """equity = EV + cash − long_term_debt (long-term debt only)."""
+        """equity = EV + cash − total_debt (LT + ST + current portion of LTD)."""
         cash = 800_000.0
         debt = 300_000.0
-        result = compute_dcf(**self.BASE_KWARGS, cash=cash, long_term_debt=debt)
+        result = compute_dcf(**self.BASE_KWARGS, cash=cash, total_debt=debt)
 
         ev = result["enterprise_value"]
         expected_equity = round(ev + cash - debt, 2)
@@ -66,7 +66,7 @@ class TestComputeDcfNetDebtAdjustment:
     def test_per_share_uses_adjusted_equity(self) -> None:
         cash = 800_000.0
         debt = 300_000.0
-        result = compute_dcf(**self.BASE_KWARGS, cash=cash, long_term_debt=debt)
+        result = compute_dcf(**self.BASE_KWARGS, cash=cash, total_debt=debt)
 
         expected_per_share = round(
             result["equity_value"] / self.BASE_KWARGS["shares_outstanding"], 2
@@ -198,7 +198,7 @@ def _minimal_financials() -> CompanyFinancials:
         entity_name="Test Co",
         free_cash_flow=fcf_series,
         diluted_shares=[_annual(1_000_000.0)],
-        long_term_debt=[_annual(500_000.0)],
+        total_debt=[_annual(500_000.0)],
         stockholders_equity=[_annual(2_000_000.0)],
         interest_expense=[_annual(25_000.0)],
         cash_and_equivalents=[_annual(800_000.0)],

--- a/backend/tests/agents/nodes/test_sec_agent_total_debt.py
+++ b/backend/tests/agents/nodes/test_sec_agent_total_debt.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``sec_agent._compute_total_debt`` aggregation.
+
+The function is the single source of truth for what "total debt" means in
+this codebase. The test cases pin three properties that downstream DCF and
+EV math rely on:
+
+1. **Component-wise sum by year** — when multiple components have a value
+   for the same calendar year, the aggregate is their sum.
+2. **No phantom zeros** — a missing component for a year does NOT zero-fill;
+   we sum only what we have. This protects against silently understating
+   debt when, say, the SEC filing didn't report ``ShortTermBorrowings`` that
+   year.
+3. **Backward compatibility** — when only ``long_term_debt`` is populated
+   (older filers, or sparse XBRL coverage) ``total_debt`` equals
+   ``long_term_debt`` exactly, so the aggregation never regresses behavior
+   relative to the pre-#9 partial-net-debt PR.
+"""
+
+from __future__ import annotations
+
+from backend.models.financial import AnnualMetric
+from backend.services.sec_agent import _compute_total_debt
+
+
+def _m(year: int, value: float, *, filed: str = "2025-01-15") -> AnnualMetric:
+    return AnnualMetric(
+        calendar_year=year,
+        value=value,
+        fiscal_year=year,
+        filing_date=filed,
+        sec_accession="0000000000-00-000000",
+        form="10-K",
+    )
+
+
+class TestComputeTotalDebt:
+    def test_all_components_present_sums_per_year(self) -> None:
+        """LTD + short-term + current portion all populate the same year."""
+        ltd = [_m(2024, 30_000.0)]
+        short = [_m(2024, 5_000.0)]
+        curr = [_m(2024, 7_000.0)]
+
+        result = _compute_total_debt([ltd, short, curr])
+
+        assert len(result) == 1
+        assert result[0].calendar_year == 2024
+        assert result[0].value == 42_000.0
+
+    def test_only_long_term_debt_passes_through_unchanged(self) -> None:
+        """Backward compat: when components beyond LTD are empty, the
+        aggregate equals the long-term debt series. Pre-#9 callers see no
+        regression."""
+        ltd = [_m(2022, 100.0), _m(2023, 110.0), _m(2024, 120.0)]
+
+        result = _compute_total_debt([ltd, [], []])
+
+        assert [m.value for m in result] == [100.0, 110.0, 120.0]
+        assert [m.calendar_year for m in result] == [2022, 2023, 2024]
+
+    def test_missing_components_skipped_not_zero_filled(self) -> None:
+        """If 2023 has only LTD and 2024 has LTD + short, the 2023 value
+        is NOT silently augmented with a zero for short-term — we only
+        sum what's actually reported."""
+        ltd = [_m(2023, 100.0), _m(2024, 100.0)]
+        short = [_m(2024, 50.0)]  # only 2024
+
+        result = _compute_total_debt([ltd, short, []])
+
+        by_year = {m.calendar_year: m.value for m in result}
+        assert by_year == {2023: 100.0, 2024: 150.0}
+
+    def test_all_empty_returns_empty(self) -> None:
+        """No data → no aggregate. Caller treats this as 'fall back to
+        debt-free DCF', matching pre-existing behavior when
+        ``long_term_debt`` was empty."""
+        assert _compute_total_debt([[], [], []]) == []
+
+    def test_metadata_anchored_to_most_recent_filing(self) -> None:
+        """When components for the same year were filed at different times
+        (e.g. a 10-K/A amendment landed for short-term debt), the aggregate
+        row's filing_date / accession traces to the latest filing so audit
+        trails point readers somewhere real."""
+        ltd = [_m(2024, 100.0, filed="2025-01-15")]
+        short = [_m(2024, 50.0, filed="2025-03-20")]  # later
+
+        result = _compute_total_debt([ltd, short, []])
+
+        assert len(result) == 1
+        assert result[0].filing_date == "2025-03-20"
+        assert result[0].value == 150.0
+
+    def test_unsorted_input_yields_sorted_output(self) -> None:
+        """Components arrive sorted from upstream extraction, but the
+        aggregator should not assume so. Pin the ordering guarantee."""
+        ltd = [_m(2024, 100.0), _m(2022, 80.0), _m(2023, 90.0)]
+
+        result = _compute_total_debt([ltd, [], []])
+
+        assert [m.calendar_year for m in result] == [2022, 2023, 2024]

--- a/docs/decisions/002-two-stage-dcf.md
+++ b/docs/decisions/002-two-stage-dcf.md
@@ -54,7 +54,12 @@ DCF 估值模型有多种阶段划分方式。核心问题是如何建模公司�
 | terminal_growth | 3.0% | 固定假设 (近似GDP增长) |
 | WACC floor | 4% | 防止不合理低价折现（原 6%，对低 beta 防御股偏高） |
 
-**部分净债务调整**: 自 2026-05 起，`per_share = (EV + cash − long_term_debt) / shares`，而非早期版本的 `EV / shares`。后者忽略资本结构，对 KO 这类高净债公司高估、对 GOOG 这类高净现金公司低估。当前仅扣**长期债务** — 短期借款 / 商业票据 / 长债当期 / 经营租赁负债待 SEC tag map 升级后补齐为完整 total debt。
+**净债务调整**: 自 2026-05 起，`per_share = (EV + cash − total_debt) / shares`，而非早期版本的 `EV / shares`。后者忽略资本结构，对 KO 这类高净债公司高估、对 GOOG 这类高净现金公司低估。`total_debt` 由 `sec_agent._compute_total_debt` 按日历年聚合：long-term debt（含 ASC 842 finance lease）+ short-term borrowings / commercial paper + current portion of long-term debt。
+
+**经营租赁负债 (operating lease liabilities) 不计入 total_debt** —— 这是个有意识的取舍：
+- **支持纳入**：ASC 842 后租赁负债出现在资产负债表，评级机构 (S&P / Moody's) 视同负债处理。
+- **支持排除（本项目立场）**：经营租赁通常不带显式利息（经济实质是租金 ≈ 经营性支出），纳入会让 cost-of-debt 分母虚增、低估 WACC，且与 `interest_expense` 实际不匹配。许多教科书 DCF / 价值投资框架同样不计。
+- **可重新评估的信号**：若发现某行业（航空、零售）DCF 系统性偏离 textbook，可在 `_compute_total_debt` 加 `OperatingLeaseLiability` component 并同步 `interest_expense` 处理重估租赁利息部分。
 
 **负权益兜底**: 若 `stockholders_equity ≤ 0`（重度回购公司如 MCD），且 `market_profile.market_cap` 可用，则用市值替代权益权重计算 WACC，避免 E/V 为负数导致的数学异常。
 

--- a/docs/nodes/01-fetch-sec-data.md
+++ b/docs/nodes/01-fetch-sec-data.md
@@ -57,6 +57,9 @@ class CompanyFinancials(BaseModel):
     free_cash_flow: list[AnnualMetric] = []          # = OCF - |CapEx|
     interest_expense: list[AnnualMetric] = []
     long_term_debt: list[AnnualMetric] = []
+    short_term_debt: list[AnnualMetric] = []                 # ShortTermBorrowings / CommercialPaper / NotesPayableCurrent
+    long_term_debt_current: list[AnnualMetric] = []          # LongTermDebtCurrent (current portion of LTD)
+    total_debt: list[AnnualMetric] = []                      # 派生: 上面三项按日历年聚合 (DCF / EV 用此字段)
     cash_and_equivalents: list[AnnualMetric] = []
     diluted_eps: list[AnnualMetric] = []
     diluted_shares: list[AnnualMetric] = []

--- a/docs/nodes/03-dcf-model.md
+++ b/docs/nodes/03-dcf-model.md
@@ -26,10 +26,10 @@
 | `financials.entity_name` | `str` | ✅ | UI 显示 |
 | `financials.ticker` | `str` | ✅ | 日志 |
 | `financials.free_cash_flow` | `list[AnnualMetric]` | ✅ | FCF 时间序列，需 ≥ 1 年；CAGR 需 ≥ 3 年 |
-| `financials.long_term_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 (缺失 → 全权益模型)，同时用作部分净债务调整中扣减项（仅长期债务） |
+| `financials.total_debt[-1].value` | `float \| None` | ⬜ | WACC 债务部分 + 净债务调整扣减项。聚合 long-term debt + short-term debt + current portion of LTD（缺失 → 全权益模型） |
 | `financials.stockholders_equity[-1].value` | `float \| None` | ⬜ | WACC 权益部分 (≤ 0 → 回退 market_cap) |
 | `financials.interest_expense[-1].value` | `float \| None` | ⬜ | 计算债务成本 |
-| `financials.cash_and_equivalents[-1].value` | `float \| None` | ⬜ | 部分净债务调整: equity_value = EV + cash − long_term_debt |
+| `financials.cash_and_equivalents[-1].value` | `float \| None` | ⬜ | 净债务调整: equity_value = EV + cash − total_debt |
 | `financials.diluted_shares[-1].value` | `float \| None` | ⬜ | 每股价值 (缺失 → `intrinsic_value_per_share = None`) |
 | `market_profile.beta` | `float \| None` | ⬜ | CAPM beta (缺失 → 回退 1.2) |
 | `market_profile.market_cap` | `float \| None` | ⬜ | 负权益时的权益权重兜底 |
@@ -98,7 +98,7 @@
 
 > **增长率估算**: `3yr CAGR × 0.6 + 5yr CAGR × 0.4`，上限 30%，下限 2%。不足时回退 10%。
 > **WACC**: `risk_free(4.5%) + beta × ERP(5.5%)` 基础 + 债务调整。Beta 优先取 `market_profile.beta` (FMP)，缺失时回退 1.2。负权益时用 market_cap 替代权益权重。下限 4%。
-> **股权价值**: `EV + cash − long_term_debt`（**部分** 净债务调整：当前 SEC tag map 仅暴露长期债务，未聚合短期借款 / 商业票据 / 长债当期 / 经营租赁负债 — 后续 PR 补全）；`per_share = equity_value / shares`。
+> **股权价值**: `EV + cash − total_debt`（净债务调整；`total_debt` = long-term debt + short-term debt + current portion of LTD，由 `sec_agent._compute_total_debt` 按日历年聚合；经营租赁负债不计入 — 见 [ADR 002](../decisions/002-two-stage-dcf.md)）；`per_share = equity_value / shares`。
 
 ### NVDA 示例 (输出)
 
@@ -156,7 +156,7 @@
    ├── Phase 2 (Y6-10): 线性衰减 growth → terminal(3%)
    ├── Terminal Value = Y10_FCF × (1+terminal) / (discount - terminal)
    ├── EV = Σ PV(FCF) + PV(TV)
-   ├── Equity Value = EV + cash − long_term_debt  (部分净债务调整, 仅长期债务)
+   ├── Equity Value = EV + cash − total_debt  (净债务调整, 含 LT/ST/current portion of LTD)
    └── Intrinsic/Share = Equity Value / diluted_shares
 ```
 
@@ -166,7 +166,7 @@
 - **独立重算端点而非重跑全图** → [ADR 004](../decisions/004-separate-recalc-endpoint.md)
 - WACC 参数：risk_free=4.5%, ERP=5.5%, tax=21% 硬编码；beta 从 FMP 动态获取（缺失时回退 1.2）
 - 增长率上限 30%，WACC 下限 4%，永续增长率固定 3%
-- 每股内在价值含**部分**净债务调整：`(EV + cash − long_term_debt) / shares`（仅扣长期债务；短期借款 / 商业票据 / 长债当期 / 租赁负债待 SEC tag map 升级后补全）
+- 每股内在价值含净债务调整：`(EV + cash − total_debt) / shares`，其中 `total_debt = long-term debt + short-term debt + current portion of LTD`（按日历年聚合，缺项不补零）；经营租赁负债不计入 — 见 [ADR 002](../decisions/002-two-stage-dcf.md)
 
 ## LLM 使用
 

--- a/docs/nodes/04-relative-valuation.md
+++ b/docs/nodes/04-relative-valuation.md
@@ -31,7 +31,7 @@
 | `financials.operating_income` | `list[AnnualMetric]` | ⬜ | EV/EBIT |
 | `financials.free_cash_flow` | `list[AnnualMetric]` | ⬜ | EV/FCF |
 | `financials.stockholders_equity` | `list[AnnualMetric]` | ⬜ | P/B |
-| `financials.long_term_debt` | `list[AnnualMetric]` | ⬜ | EV |
+| `financials.total_debt` | `list[AnnualMetric]` | ⬜ | EV (优先使用聚合 total_debt；缺失时回退到 long_term_debt) |
 | `financials.cash_and_equivalents` | `list[AnnualMetric]` | ⬜ | EV |
 | `financials.depreciation_and_amortization` | `list[AnnualMetric]` | ⬜ | FFO |
 


### PR DESCRIPTION
## Summary

Closes the partial-debt gap left open by #9. Adds short-term borrowings + current portion of long-term debt to the SEC ingestion, derives a `total_debt` aggregate, and switches DCF + relative-valuation EV math to use it.

For **KO** this closes the ~\$8 gap noted in PR #9's e2e verification (IV/share \$61.66 → ~\$70 textbook): KO carries multi-billion short-term + LTD-current that were previously ignored. For tickers without these components in their XBRL data, `total_debt` equals `long_term_debt` and behavior is unchanged.

## Why

PR #9 description explicitly listed this as the next step. PR #10 covered the ASC 842 lease-inclusive long-term debt tag — this PR completes the picture for the remaining short-term components.

## What's in scope

| Layer | Change |
|---|---|
| Model | `CompanyFinancials` gains `short_term_debt`, `long_term_debt_current`, `total_debt` fields. `long_term_debt` retained (still used by `logic_trace` audit display). |
| SEC | `TAG_MAP` adds `ShortTermBorrowings` / `CommercialPaper` / `NotesPayableCurrent` (short-term) and `LongTermDebtCurrent` (current portion). New `_compute_total_debt` aggregates components by calendar year. |
| DCF | `compute_dcf(long_term_debt=…)` → `compute_dcf(total_debt=…)`. `_run_dcf` reads `financials.total_debt` for both WACC weighting and net-debt subtraction (consistent debt scope across the formula). |
| Event impact | `recalculate_dcf` parameter rename; `/api/recalculate-dcf` route updated. |
| Relative valuation | EV math (`compute_current_multiples` + `compute_historical_multiples`) prefers `total_debt`, falls back to `long_term_debt` for sparse coverage. |
| Tests | New `test_sec_agent_total_debt.py` (6 cases) pinning aggregation contract. `test_dcf_model.py` parameter renames. |
| Docs | ADR 002 documents the operating-lease exclusion choice with the signal that would prompt re-evaluation. `03-dcf-model.md`, `01-fetch-sec-data.md`, `04-relative-valuation.md` aligned. |

## What's NOT in scope

- **Operating lease liabilities** are intentionally excluded from `total_debt`. This is a defensible analytical choice (no explicit interest, ASC 842 capitalizes a rent-stream economic substance, mismatch with `interest_expense`). Decision documented in ADR 002 with a re-evaluation trigger.
- 30 % growth-rate cap dynamic adjustment (future)
- DCF inappropriateness detection for option-value names (future)
- `risk_free_rate` from FMP (future)

## Aggregation contract (worth a careful look)

`_compute_total_debt` enforces three properties via tests:

1. **Component-wise sum by year** — when multiple components have a value for the same year, the aggregate is their sum.
2. **No zero-fill** — a missing component for a year does NOT become a phantom zero. We sum only what's reported.
3. **Backward compat** — when only `long_term_debt` is populated, `total_debt` equals it exactly.

Plus a metadata-anchoring rule: the aggregate row's `filing_date` / `accession` traces to the latest-filed component, so audit trails point readers to a real filing.

## Test plan

- [x] 152/152 tests pass (was 146 + 6 new aggregation tests)
- [x] Spot-check: pre-#9 fixtures still pass via the backward-compat path
- [ ] **Reviewer can verify on KO live** — run analyze, expect IV/share to land ~\$66-70 (was \$61.66 with #9 alone). MCD also a good ticker (heavy current-portion of LTD).

## Where to focus review

1. **`_compute_total_debt`** ([backend/services/sec_agent.py](https://github.com/hymanqiu/alphaquant/blob/feature/dcf-full-total-debt/backend/backend/services/sec_agent.py)) — aggregation logic + no-zero-fill semantics. Specifically the metadata-anchoring choice (latest-filed wins for traceability).
2. **Operating-lease exclusion in ADR 002** — disagreement here is reasonable; sanity-check the documented re-evaluation trigger.
3. **EV math in `relative_valuation_math.py`** — same `total_debt` fallback pattern; verify the `or` short-circuit reads cleanly.