### PR TITLE
chore: ignore local Excel scratch files (.xlsx + lock files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ backend/alembic/__pycache__/
 
 # Frontend incremental build cache
 frontend/tsconfig.tsbuildinfo
+
+# Local financial model spreadsheets (personal scratch, never commit)
+*.xlsx
+*.xls
+~$*.xlsx
+~$*.xls


### PR DESCRIPTION
1 行 + .gitignore 6 行的卫生补丁。Excel 模型（如 `KO_DCF_Model_Update.xlsx`）在 DCF 调研时常被丢进工作树，从来不该 track。预防性 ignore `*.xlsx`/`*.xls` + Excel 的 `~$*.xlsx` 锁文件。

无 tracked xlsx 受影响（`git ls-files | grep -iE '.xlsx?\$'` 验过空）。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>