### PR TITLE
fix(makefile): activate venv from inside backend dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 PYTHON ?= python3
 BACKEND := backend
 FRONTEND := frontend
-VENV := $(BACKEND)/.venv
+VENV := .venv
 ACTIVATE := . $(VENV)/bin/activate
 
 # Defaulting to "help" instead of "all" so a bare `make` doesn't blow anything up.


### PR DESCRIPTION
## Summary

- \`VENV := \$(BACKEND)/.venv\` expanded to \`backend/.venv\`, but every target uses \`\$(ACTIVATE)\` *after* \`cd \$(BACKEND)\`, so the path resolved to the nonexistent \`backend/backend/.venv/bin/activate\`.
- Fix: drop the \`backend/\` prefix; \`. .venv/bin/activate\` is now correct relative to the cwd inside each target.
- Restores \`make backend\`, \`make dev\`, \`make test\`, \`make migrate\`, \`make migrate-down\`, \`make migrate-new\`.

## Test plan
- [x] \`make backend\` — Uvicorn starts on :8000
- [x] \`curl /api/auth/me\` returns 401 (not ECONNREFUSED)
- [x] \`make test\` — 152 passed
- [x] \`make migrate\` — alembic runs against Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)